### PR TITLE
Feat: 쏠렉트 수정 및 삭제 기능 구현 (#26)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/review/service/ReviewService.java
+++ b/src/main/java/com/ilta/solepli/domain/review/service/ReviewService.java
@@ -75,12 +75,12 @@ public class ReviewService {
 
     // 리뷰 이미지 저장
     if (files.size() > 5) {
-      throw new CustomException(ErrorCode.TOO_MANY_IMAGES);
+      throw new CustomException(ErrorCode.TOO_MANY_REVIEW_IMAGES);
     }
 
     List<ReviewImage> reviewImages = new ArrayList<>();
     for (MultipartFile file : files) {
-      if (file.getSize() > 10 * 1024 * 1024)
+      if (file.getSize() > 5 * 1024 * 1024)
         throw new CustomException(ErrorCode.IMAGE_SIZE_EXCEEDED);
       String imageUrl = s3Service.uploadReviewImage(file);
       ReviewImage reviewImage = ReviewImage.builder().imageUrl(imageUrl).review(review).build();

--- a/src/main/java/com/ilta/solepli/domain/solelect/controller/SolelectController.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/controller/SolelectController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -75,5 +76,13 @@ public class SolelectController {
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     solelectService.updateSolelect(id, request, userDetails.user());
     return ResponseEntity.ok().body(SuccessResponse.successWithNoData("쏠렉트 수정 성공"));
+  }
+
+  @Operation(summary = "쏠렉트 삭제 API", description = "쏠렉트를 삭제하는 API입니다.")
+  @DeleteMapping("/{id}")
+  public ResponseEntity<SuccessResponse<Void>> deleteSolelect(
+      @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    solelectService.deleteSolelect(id, userDetails.user());
+    return ResponseEntity.ok().body(SuccessResponse.successWithNoData("쏠렉트 삭제 성공"));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solelect/controller/SolelectController.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/controller/SolelectController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -21,6 +22,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import com.ilta.solepli.domain.solelect.dto.request.SolelectCreateRequest;
+import com.ilta.solepli.domain.solelect.dto.request.SolelectUpdateRequest;
 import com.ilta.solepli.domain.solelect.dto.response.SolelectCreateResponse;
 import com.ilta.solepli.domain.solelect.service.SolelectService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
@@ -38,7 +40,7 @@ public class SolelectController {
       summary = "쏠렉트 등록 API",
       description =
           "쏠렉트를 등록하는 API입니다. 제목, 내용, 장소 ID들을 보내주세요. 여기서 내용은 타입 (TEXT or IMAGE), 순서, 내용(TEXT의 경우 글의 내용, IMAGE의 경우 이미지 파일의 이름)입니다.")
-  @PostMapping()
+  @PostMapping
   public ResponseEntity<SuccessResponse<SolelectCreateResponse>> createSolelect(
       @Valid @RequestBody SolelectCreateRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -49,7 +51,7 @@ public class SolelectController {
                 solelectService.createSolelect(request, userDetails.user())));
   }
 
-  @Operation(summary = "쏠렉트 이미지 업로드 API", description = "쏠렉트의 이미지를 업로드하는 API입니다.")
+  @Operation(summary = "쏠렉트 이미지 업로드 API", description = "쏠렉트의 이미지를 업로드하는 API입니다. (등록 or 수정시 사용)")
   @PostMapping(value = "/{id}/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<SuccessResponse<Void>> uploadSolelectImage(
       @PathVariable Long id,
@@ -63,5 +65,15 @@ public class SolelectController {
     solelectService.uploadSolelectImage(id, files, userDetails.user());
 
     return ResponseEntity.ok().body(SuccessResponse.successWithNoData("쏠렉트 이미지 업로드 성공"));
+  }
+
+  @Operation(summary = "쏠렉트 수정 API", description = "쏠렉트를 수정하는 API입니다.")
+  @PutMapping("/{id}")
+  public ResponseEntity<SuccessResponse<Void>> updateSolelect(
+      @PathVariable Long id,
+      @RequestBody SolelectUpdateRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    solelectService.updateSolelect(id, request, userDetails.user());
+    return ResponseEntity.ok().body(SuccessResponse.successWithNoData("쏠렉트 수정 성공"));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solelect/dto/request/SolelectUpdateRequest.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/dto/request/SolelectUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.ilta.solepli.domain.solelect.dto.request;
+
+import java.util.List;
+
+import lombok.Builder;
+
+import com.ilta.solepli.domain.solelect.entity.ContentType;
+
+@Builder
+public record SolelectUpdateRequest(
+    String title, List<SolelectContent> contents, List<Long> placeIds) {
+
+  public record SolelectContent(Long seq, ContentType type, String content) {}
+}

--- a/src/main/java/com/ilta/solepli/domain/solelect/entity/Solelect.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/entity/Solelect.java
@@ -49,4 +49,8 @@ public class Solelect {
   @OneToMany(mappedBy = "solelect", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   private List<SolelectContent> solelectContents = new ArrayList<>();
+
+  public void updateTitle(String title) {
+    this.title = title;
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/solelect/entity/Solelect.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/entity/Solelect.java
@@ -23,6 +23,7 @@ import org.hibernate.annotations.OnDeleteAction;
 
 import com.ilta.solepli.domain.solelect.entity.mapping.SolelectPlace;
 import com.ilta.solepli.domain.user.entity.User;
+import com.ilta.solepli.global.entity.Timestamped;
 
 @Entity
 @Getter
@@ -30,7 +31,7 @@ import com.ilta.solepli.domain.user.entity.User;
 @AllArgsConstructor
 @Builder
 @Table(name = "solelects")
-public class Solelect {
+public class Solelect extends Timestamped {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/src/main/java/com/ilta/solepli/domain/solelect/entity/SolelectContent.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/entity/SolelectContent.java
@@ -19,13 +19,15 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+import com.ilta.solepli.global.entity.Timestamped;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Table(name = "solelect_contents")
-public class SolelectContent {
+public class SolelectContent extends Timestamped {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/src/main/java/com/ilta/solepli/domain/solelect/entity/mapping/SolelectPlace.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/entity/mapping/SolelectPlace.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.OnDeleteAction;
 
 import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.solelect.entity.Solelect;
+import com.ilta.solepli.global.entity.Timestamped;
 
 @Entity
 @Getter
@@ -25,7 +26,7 @@ import com.ilta.solepli.domain.solelect.entity.Solelect;
 @AllArgsConstructor
 @Builder
 @Table(name = "solelect_places")
-public class SolelectPlace {
+public class SolelectPlace extends Timestamped {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/src/main/java/com/ilta/solepli/domain/solelect/repository/SolelectContentRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/repository/SolelectContentRepository.java
@@ -1,7 +1,15 @@
 package com.ilta.solepli.domain.solelect.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.ilta.solepli.domain.solelect.entity.Solelect;
 import com.ilta.solepli.domain.solelect.entity.SolelectContent;
 
-public interface SolelectContentRepository extends JpaRepository<SolelectContent, Long> {}
+public interface SolelectContentRepository extends JpaRepository<SolelectContent, Long> {
+  @Modifying
+  @Query("DELETE FROM SolelectContent sc WHERE sc.solelect = :solelect")
+  void deleteBySolelect(@Param("solelect") Solelect solelect);
+}

--- a/src/main/java/com/ilta/solepli/domain/solelect/repository/SolelectPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/repository/SolelectPlaceRepository.java
@@ -1,7 +1,15 @@
 package com.ilta.solepli.domain.solelect.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.ilta.solepli.domain.solelect.entity.Solelect;
 import com.ilta.solepli.domain.solelect.entity.mapping.SolelectPlace;
 
-public interface SolelectPlaceRepository extends JpaRepository<SolelectPlace, Long> {}
+public interface SolelectPlaceRepository extends JpaRepository<SolelectPlace, Long> {
+  @Modifying
+  @Query("DELETE FROM SolelectPlace sp WHERE sp.solelect = :solelect")
+  void deleteBySolelect(@Param("solelect") Solelect solelect);
+}

--- a/src/main/java/com/ilta/solepli/domain/solelect/repository/SolelectRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/repository/SolelectRepository.java
@@ -4,13 +4,12 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.ilta.solepli.domain.solelect.entity.Solelect;
 
 public interface SolelectRepository extends JpaRepository<Solelect, Long> {
   @EntityGraph(attributePaths = {"user", "solelectContents"})
-  @Query("SELECT s FROM Solelect s WHERE s.id = :id AND s.deleteAt IS NULL")
+  //  @Query("SELECT s FROM Solelect s WHERE s.id = :id AND s.deletedAt IS NULL")
   Optional<Solelect> findWithContentById(@Param("id") Long id);
 }

--- a/src/main/java/com/ilta/solepli/domain/solelect/repository/SolelectRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/repository/SolelectRepository.java
@@ -4,10 +4,13 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.ilta.solepli.domain.solelect.entity.Solelect;
 
 public interface SolelectRepository extends JpaRepository<Solelect, Long> {
   @EntityGraph(attributePaths = {"user", "solelectContents"})
-  Optional<Solelect> findWithContentById(Long id);
+  @Query("SELECT s FROM Solelect s WHERE s.id = :id AND s.deleteAt IS NULL")
+  Optional<Solelect> findWithContentById(@Param("id") Long id);
 }

--- a/src/main/java/com/ilta/solepli/domain/solelect/service/SolelectService.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/service/SolelectService.java
@@ -202,8 +202,11 @@ public class SolelectService {
       throw new CustomException(ErrorCode.SOLELECT_FORBIDDEN);
     }
 
-    deleteS3Images(solelect.getSolelectContents());
-    solelectRepository.delete(solelect);
+    // 추후에 S3 용량 문제 발생시 다시 활성화
+    // deleteS3Images(solelect.getSolelectContents());
+
+    solelect.softDelete();
+    // solelectRepository.delete(solelect);
   }
 
   private SolelectContent findImage(List<SolelectContent> solelectContents, String filename) {

--- a/src/main/java/com/ilta/solepli/domain/solelect/service/SolelectService.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/service/SolelectService.java
@@ -2,6 +2,7 @@ package com.ilta.solepli.domain.solelect.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -138,7 +139,7 @@ public class SolelectService {
     }
 
     // 기존 쏠렉트 장소와 쏠렉트 콘텐츠 삭제 후 다시 저장
-    deleteImages(solelect.getSolelectContents());
+    deleteS3Images(solelect.getSolelectContents());
     solelectPlaceRepository.deleteBySolelect(solelect);
     solelectPlaceRepository.flush();
     solelectContentRepository.deleteBySolelect(solelect);
@@ -201,7 +202,7 @@ public class SolelectService {
       throw new CustomException(ErrorCode.SOLELECT_FORBIDDEN);
     }
 
-    deleteImages(solelect.getSolelectContents());
+    deleteS3Images(solelect.getSolelectContents());
     solelectRepository.delete(solelect);
   }
 
@@ -215,10 +216,11 @@ public class SolelectService {
     return null;
   }
 
-  private void deleteImages(List<SolelectContent> solelectContents) {
+  private void deleteS3Images(List<SolelectContent> solelectContents) {
     solelectContents.stream()
         .filter(content -> content.getType() == ContentType.IMAGE)
         .map(SolelectContent::getImageUrl)
+        .filter(Objects::nonNull) // null인 경우 필터링
         .forEach(s3Service::deleteSolelectImage);
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solelect/service/SolelectService.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/service/SolelectService.java
@@ -189,6 +189,22 @@ public class SolelectService {
     solelectContentRepository.saveAll(solelectContents);
   }
 
+  @Transactional
+  public void deleteSolelect(Long id, User user) {
+    Solelect solelect =
+        solelectRepository
+            .findWithContentById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.SOLELECT_NOT_FOUND));
+
+    // 쏠렉트 소유자가 맞는지 검증
+    if (!solelect.getUser().getId().equals(user.getId())) {
+      throw new CustomException(ErrorCode.SOLELECT_FORBIDDEN);
+    }
+
+    deleteImages(solelect.getSolelectContents());
+    solelectRepository.delete(solelect);
+  }
+
   private SolelectContent findImage(List<SolelectContent> solelectContents, String filename) {
     for (SolelectContent solelectContent : solelectContents) {
       if (solelectContent.getType().equals(ContentType.IMAGE)

--- a/src/main/java/com/ilta/solepli/domain/solelect/service/SolelectService.java
+++ b/src/main/java/com/ilta/solepli/domain/solelect/service/SolelectService.java
@@ -105,6 +105,11 @@ public class SolelectService {
 
     List<SolelectContent> solelectContents = solelect.getSolelectContents();
 
+    if (files.size() > 100) {
+      solelectRepository.delete(solelect);
+      throw new CustomException(ErrorCode.TOO_MANY_SOLELECT_IMAGES);
+    }
+
     for (MultipartFile file : files) {
       String filename = file.getOriginalFilename();
       SolelectContent solelectContent = findImage(solelectContents, filename);

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -49,7 +49,7 @@ public enum ErrorCode {
 
   // 리뷰 등록 관련 에러
   REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "해당 장소에 이미 리뷰를 작성하셨습니다."),
-  TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "리뷰 사진은 최대 5장까지 가능합니다."),
+  TOO_MANY_REVIEW_IMAGES(HttpStatus.BAD_REQUEST, "리뷰 사진은 최대 5장까지 가능합니다."),
   INVALID_RECOMMENDATION(HttpStatus.BAD_REQUEST, "1인 추천 여부는 필수입니다."),
   INVALID_PLACE_ID_NULL(HttpStatus.BAD_REQUEST, "장소 ID는 필수입니다."),
   INVALID_RATING_NULL(HttpStatus.BAD_REQUEST, "평점은 필수입니다."),

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
   // 쏠렉트 관련 에러
   SOLELECT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 쏠렉트입니다."),
   SOLELECT_FORBIDDEN(HttpStatus.FORBIDDEN, "쏠렉트의 소유자가 아닙니다."),
+  TOO_MANY_SOLELECT_IMAGES(HttpStatus.BAD_REQUEST, "쏠렉트 사진은 최대 100장까지 가능합니다."),
   CONTENT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 콘텐츠 이미지를 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/ilta/solepli/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ilta/solepli/global/exception/handler/GlobalExceptionHandler.java
@@ -122,7 +122,7 @@ public class GlobalExceptionHandler {
 
     log.error("handleMultipartException : {}", ex.getMessage());
 
-    String message = "파일 업로드 용량을 초과했습니다. 각 파일은 최대 5MB, 총 요청은 최대 100MB까지 허용됩니다.";
+    String message = "파일 업로드 용량을 초과했습니다. 각 파일은 최대 5MB, 총 요청은 최대 500MB까지 허용됩니다.";
 
     ErrorResponse response =
         ErrorResponse.create().message(message).httpStatus(HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/ilta/solepli/global/service/S3Service.java
+++ b/src/main/java/com/ilta/solepli/global/service/S3Service.java
@@ -102,7 +102,7 @@ public class S3Service {
 
   public void deleteProfileImage(String fileUrl) {
     try {
-      amazonS3.deleteObject(profileFolderName, extractKeyFromUrl(fileUrl));
+      amazonS3.deleteObject(bucketName, extractKeyFromUrl(fileUrl));
     } catch (AmazonServiceException e) {
       throw new CustomException(ErrorCode.S3_DELETE_FAILURE);
     }
@@ -110,7 +110,7 @@ public class S3Service {
 
   public void deleteReviewImage(String fileUrl) {
     try {
-      amazonS3.deleteObject(reviewFolderName, extractKeyFromUrl(fileUrl));
+      amazonS3.deleteObject(bucketName, extractKeyFromUrl(fileUrl));
     } catch (AmazonServiceException e) {
       throw new CustomException(ErrorCode.S3_DELETE_FAILURE);
     }
@@ -118,7 +118,8 @@ public class S3Service {
 
   public void deleteSolelectImage(String fileUrl) {
     try {
-      amazonS3.deleteObject(solelectFolderName, extractKeyFromUrl(fileUrl));
+      System.out.println(extractKeyFromUrl(fileUrl));
+      amazonS3.deleteObject(bucketName, extractKeyFromUrl(fileUrl));
     } catch (AmazonServiceException e) {
       throw new CustomException(ErrorCode.S3_DELETE_FAILURE);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
   servlet:
     multipart:
       max-file-size: 5MB # 업로드할 수 있는 개별 파일의 최대 크기.
-      max-request-size: 100MB # multipart/form-data 요청의 최대 허용 크기.
+      max-request-size: 500MB # multipart/form-data 요청의 최대 허용 크기.
 
   # JWT
   jwt:


### PR DESCRIPTION
## #️⃣ Issue Number
#26 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
리뷰 이미지 용량 관련 리팩토링 진행했고,
쏠렉트의 수정 및 삭제 기능 구현 완료했습니다.

쏠렉트 수정은 기존의 Solelect에 연결되어 있는 SolelectContent와 SolelectPlace를 지우고
모든 정보를 다 다시 받아서 등록과 같은 흐름으로 동작하도록 구현했습니다.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

