### PR TITLE
Feat: 쏠렉트 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,14 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// QueryDSL core
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+
+	// APT 설정 (Annotation Processor)
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 // Spotless 설정 (코드 스타일 자동 정리 도구)

--- a/src/main/java/com/ilta/solepli/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/category/repository/CategoryRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ilta.solepli.domain.category.entity.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-
   boolean existsByName(String name);
 }

--- a/src/main/java/com/ilta/solepli/domain/review/entity/Review.java
+++ b/src/main/java/com/ilta/solepli/domain/review/entity/Review.java
@@ -26,6 +26,7 @@ import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.review.entity.mapping.ReviewImage;
 import com.ilta.solepli.domain.review.entity.mapping.ReviewTag;
 import com.ilta.solepli.domain.user.entity.User;
+import com.ilta.solepli.global.entity.Timestamped;
 
 @Entity
 @Getter
@@ -33,7 +34,7 @@ import com.ilta.solepli.domain.user.entity.User;
 @AllArgsConstructor
 @Builder
 @Table(name = "reviews")
-public class Review {
+public class Review extends Timestamped {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ilta/solepli/domain/sollect/controller/SollectController.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/controller/SollectController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,6 +28,7 @@ import com.ilta.solepli.domain.sollect.dto.request.KeywordRequest;
 import com.ilta.solepli.domain.sollect.dto.request.SollectCreateRequest;
 import com.ilta.solepli.domain.sollect.dto.request.SollectUpdateRequest;
 import com.ilta.solepli.domain.sollect.dto.response.SollectCreateResponse;
+import com.ilta.solepli.domain.sollect.dto.response.SollectSearchResponse;
 import com.ilta.solepli.domain.sollect.service.SollectService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
 import com.ilta.solepli.global.response.SuccessResponse;
@@ -119,5 +121,19 @@ public class SollectController {
     sollectService.deleteRecentSearch(customUserDetails.getUsername(), keyword);
 
     return ResponseEntity.ok(SuccessResponse.successWithNoData(keyword + " 검색어 삭제 성공"));
+  }
+
+  @Operation(summary = "쏠렉트 검색 API", description = "키워드 + 카테고리명으로 쏠렉트를 검색하는 API 입니다.")
+  @GetMapping("/search")
+  public ResponseEntity<SuccessResponse<SollectSearchResponse>> searchSollect(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "6") int size,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) String category) {
+
+    SollectSearchResponse searchContents =
+        sollectService.getSearchContents(page, size, keyword, category);
+
+    return ResponseEntity.ok(SuccessResponse.successWithData(searchContents));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/dto/SollectSearchResponseContent.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/dto/SollectSearchResponseContent.java
@@ -1,0 +1,15 @@
+package com.ilta.solepli.domain.sollect.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record SollectSearchResponseContent(
+    String thumbnailImage, String title, String district, String neighborhood) {
+  @QueryProjection
+  public SollectSearchResponseContent(
+      String thumbnailImage, String title, String district, String neighborhood) {
+    this.thumbnailImage = thumbnailImage;
+    this.title = title;
+    this.district = district;
+    this.neighborhood = neighborhood;
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/sollect/dto/response/SollectSearchResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/dto/response/SollectSearchResponse.java
@@ -1,0 +1,15 @@
+package com.ilta.solepli.domain.sollect.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record SollectSearchResponse(List<SollectSearchContent> contents, PageInfo pageInfo) {
+  @Builder
+  public record SollectSearchContent(
+      String thumbnailImage, String title, String district, String neighborhood) {}
+
+  @Builder
+  public record PageInfo(int page, int size, int totalPages, long totalElements, boolean isLast) {}
+}

--- a/src/main/java/com/ilta/solepli/domain/sollect/entity/mapping/SollectPlace.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/entity/mapping/SollectPlace.java
@@ -41,5 +41,5 @@ public class SollectPlace extends Timestamped {
   @OnDelete(action = OnDeleteAction.CASCADE)
   private Place place;
 
-  private int seq;
+  private Integer seq;
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/entity/mapping/SollectPlace.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/entity/mapping/SollectPlace.java
@@ -40,4 +40,6 @@ public class SollectPlace extends Timestamped {
   @JoinColumn(name = "place_id")
   @OnDelete(action = OnDeleteAction.CASCADE)
   private Place place;
+
+  private int seq;
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryCustom.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.ilta.solepli.domain.sollect.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.ilta.solepli.domain.sollect.dto.SollectSearchResponseContent;
+
+@Repository
+public interface SollectRepositoryCustom {
+  Page<SollectSearchResponseContent> searchSollectByKeywordOrCategory(
+      Pageable pageable, String parsedKeyword, String parsedCategory);
+}

--- a/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryImpl.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryImpl.java
@@ -1,0 +1,125 @@
+package com.ilta.solepli.domain.sollect.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import com.ilta.solepli.domain.category.entity.QCategory;
+import com.ilta.solepli.domain.place.entity.QPlace;
+import com.ilta.solepli.domain.place.entity.mapping.QPlaceCategory;
+import com.ilta.solepli.domain.sollect.dto.QSollectSearchResponseContent;
+import com.ilta.solepli.domain.sollect.dto.SollectSearchResponseContent;
+import com.ilta.solepli.domain.sollect.entity.QSollect;
+import com.ilta.solepli.domain.sollect.entity.QSollectContent;
+import com.ilta.solepli.domain.sollect.entity.mapping.QSollectPlace;
+
+@RequiredArgsConstructor
+public class SollectRepositoryImpl implements SollectRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  QSollect sollect = QSollect.sollect;
+  QSollectPlace sollectPlace = QSollectPlace.sollectPlace;
+  QSollectContent sollectContent = QSollectContent.sollectContent;
+  QPlace place = QPlace.place;
+  QPlaceCategory placeCategory = QPlaceCategory.placeCategory;
+  QCategory category = QCategory.category;
+
+  @Override
+  public Page<SollectSearchResponseContent> searchSollectByKeywordOrCategory(
+      Pageable pageable, String parsedKeyword, String parsedCategory) {
+
+    // 1. 둘 다 null이면 빈 페이지 반환
+    if ((parsedKeyword == null || parsedKeyword.isBlank())
+        && (parsedCategory == null || parsedCategory.isBlank())) {
+      return Page.empty(pageable);
+    }
+
+    // 2. 키워드/카테고리에 맞는 Place ID 찾기
+    List<Long> placeIds =
+        queryFactory
+            .select(place.id)
+            .from(place)
+            .leftJoin(place.placeCategories, placeCategory)
+            .leftJoin(placeCategory.category, category)
+            .where(anyMatchKeyword(parsedKeyword), matchCategory(parsedCategory))
+            .fetch();
+
+    // 3. 안전하게 조합된 keyword 조건
+    BooleanBuilder keywordCondition = new BooleanBuilder();
+    BooleanExpression titleCondition = matchSollectTitle(parsedKeyword);
+    BooleanExpression placeCondition =
+        placeIds.isEmpty() ? null : sollectPlace.place.id.in(placeIds);
+
+    if (titleCondition != null) {
+      keywordCondition.or(titleCondition);
+    }
+    if (placeCondition != null) {
+      keywordCondition.or(placeCondition);
+    }
+
+    // 첫 번째 장소용 Alias 분리
+    QSollectPlace firstPlace = new QSollectPlace("firstPlace");
+    QPlace firstPlaceInfo = new QPlace("firstPlaceInfo");
+
+    // 4. 본문 쿼리
+    List<SollectSearchResponseContent> result =
+        queryFactory
+            .select(
+                new QSollectSearchResponseContent(
+                    sollectContent.imageUrl,
+                    sollect.title,
+                    firstPlaceInfo.district,
+                    firstPlaceInfo.neighborhood))
+            .from(sollect)
+            .join(sollect.sollectPlaces, sollectPlace)
+            .join(sollectPlace.place, place)
+            .join(sollect.sollectPlaces, firstPlace)
+            .on(firstPlace.seq.eq(0))
+            .join(firstPlace.place, firstPlaceInfo)
+            .join(sollect.sollectContents, sollectContent)
+            .where(sollectContent.seq.eq(0L), keywordCondition)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(sollect.createdAt.desc())
+            .fetch();
+
+    // 5. 총 개수 카운트
+    Long count =
+        queryFactory
+            .select(sollect.countDistinct())
+            .from(sollect)
+            .join(sollect.sollectPlaces, sollectPlace)
+            .where(keywordCondition)
+            .fetchOne();
+
+    return new PageImpl<>(result, pageable, Optional.ofNullable(count).orElse(0L));
+  }
+
+  private BooleanExpression anyMatchKeyword(String keyword) {
+    if (keyword == null || keyword.isBlank()) return null;
+    return place
+        .address
+        .containsIgnoreCase(keyword)
+        .or(place.district.containsIgnoreCase(keyword))
+        .or(place.neighborhood.containsIgnoreCase(keyword));
+  }
+
+  private BooleanExpression matchCategory(String categoryName) {
+    if (categoryName == null || categoryName.isBlank()) return null;
+    return category.name.eq(categoryName);
+  }
+
+  private BooleanExpression matchSollectTitle(String keyword) {
+    if (keyword == null || keyword.isBlank()) return null;
+    return sollect.title.containsIgnoreCase(keyword);
+  }
+}

--- a/src/main/java/com/ilta/solepli/global/config/QueryDslConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.ilta.solepli.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+  @PersistenceContext private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                         "/v3/api-docs/**",
                         "/health/**")
                     .permitAll()
-                    .requestMatchers("/api/auth/**", "/api/solmap/markers")
+                    .requestMatchers("/api/auth/**", "/api/solmap/markers", "/api/sollect/search")
                     .permitAll() // 로그인과 회원가입은 인증 없이 접근 가능
                     .anyRequest()
                     .authenticated() // 그 외 요청은 인증 필요


### PR DESCRIPTION
## #️⃣ Issue Number
#26 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
페이징을 이용해서 조회할 수 있도록 했고,
키워드(구, 동, 쏠렉트 제목)로 검색 , 키워드 + 카테고리로 검색 카테고리로만 검색 할 수 있도록 구현했습니다!

```
public Page<SollectSearchResponseContent> searchSollectByKeywordOrCategory(
      Pageable pageable, String parsedKeyword, String parsedCategory) {

    // 1. 키워드 또는 카테고리에 해당하는 Place ID 추출
    List<Long> placeIds =
        queryFactory
            .select(place.id)
            .from(place)
            .leftJoin(place.placeCategories, placeCategory)
            .leftJoin(placeCategory.category, category)
            .where(anyMatchKeyword(parsedKeyword), matchCategory(parsedCategory))
            .fetch();

    // 2. Sollect ID 추출 (title OR place 조건 만족)
    BooleanBuilder sollectCondition = new BooleanBuilder();
    BooleanExpression titleCondition = matchSollectTitle(parsedKeyword);
    BooleanExpression placeCondition =
        placeIds.isEmpty() ? null : sollectPlace.place.id.in(placeIds);

    if (titleCondition != null) sollectCondition.or(titleCondition);
    if (placeCondition != null) sollectCondition.or(placeCondition);

    List<Tuple> sollectTuples =
        queryFactory
            .select(sollect.id, sollect.createdAt)
            .from(sollect)
            .leftJoin(sollect.sollectPlaces, sollectPlace)
            .where(sollectCondition)
            .distinct()
            .offset(pageable.getOffset())
            .limit(pageable.getPageSize())
            .orderBy(sollect.createdAt.desc())
            .fetch();

    // ID만 추출
    List<Long> sollectIds = sollectTuples.stream().map(tuple -> tuple.get(sollect.id)).toList();

    // 3. DTO 추출 (대표 장소, 대표 콘텐츠)
    QSollectPlace firstPlace = new QSollectPlace("firstPlace");
    QPlace firstPlaceInfo = new QPlace("firstPlaceInfo");

    List<SollectSearchResponseContent> result =
        queryFactory
            .select(
                new QSollectSearchResponseContent(
                    sollectContent.imageUrl,
                    sollect.title,
                    firstPlaceInfo.district,
                    firstPlaceInfo.neighborhood))
            .from(sollect)
            .join(sollect.sollectPlaces, firstPlace)
            .on(firstPlace.seq.eq(0))
            .join(firstPlace.place, firstPlaceInfo)
            .join(sollect.sollectContents, sollectContent)
            .on(sollectContent.seq.eq(0L))
            .where(sollect.id.in(sollectIds))
            .orderBy(sollect.createdAt.desc())
            .fetch();

    // 4. 전체 개수 추출
    Long count =
        queryFactory
            .select(sollect.countDistinct())
            .from(sollect)
            .leftJoin(sollect.sollectPlaces, sollectPlace)
            .where(sollectCondition)
            .fetchOne();

    return new PageImpl<>(result, pageable, Optional.ofNullable(count).orElse(0L));
  } 
```
1. 키워드 또는 카테고리에 해당하는 Place ID 추출
2. Sollect ID 추출 (title OR place 조건 만족)
3. DTO 추출
4. Count 쿼리 

이 순서로 진행했는데, 더 좋은 방법이 있다면 추후에 리팩토링해도 좋을 거 같습니다!

그리고 SollectPlace에 대표 장소 여부 (첫 번째로 추가한 장소)를 판단하기 위해 seq 필드를 추가했습니다!
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정

