### PR TITLE
Feat: 쏠맵 연관 검색어 조회 API 구현

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.ilta.solepli.domain.solmap.dto.KeywordRequest;
 import com.ilta.solepli.domain.solmap.dto.PlaceSearchPreviewResponse;
+import com.ilta.solepli.domain.solmap.dto.RelatedSearchResponse;
 import com.ilta.solepli.domain.solmap.dto.ViewportMapMarkerDetail;
 import com.ilta.solepli.domain.solmap.service.SolmapService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
@@ -96,5 +97,16 @@ public class SolmapController {
             swLat, swLng, neLat, neLng, userLat, userLng, category, cursorId, cursorDist, limit);
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+  }
+
+  @Operation(summary = "연관 검색어 조회 API", description = "연관 검색어 조회 API 입니다.")
+  @GetMapping("search/related")
+  public ResponseEntity<SuccessResponse<List<RelatedSearchResponse>>> getRelatedSearch(
+      @RequestParam String keyword, @RequestParam Double userLat, @RequestParam Double userLng) {
+
+    List<RelatedSearchResponse> response =
+        solmapService.getRelatedSearch(keyword, userLat, userLng);
+
+    return ResponseEntity.ok(SuccessResponse.successWithData(response));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -12,9 +12,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import com.ilta.solepli.domain.solmap.dto.KeywordRequest;
+import com.ilta.solepli.domain.solmap.dto.MarkerResponse;
 import com.ilta.solepli.domain.solmap.dto.PlaceSearchPreviewResponse;
 import com.ilta.solepli.domain.solmap.dto.RelatedSearchResponse;
-import com.ilta.solepli.domain.solmap.dto.ViewportMapMarkerDetail;
 import com.ilta.solepli.domain.solmap.service.SolmapService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
 import com.ilta.solepli.global.response.SuccessResponse;
@@ -29,7 +29,7 @@ public class SolmapController {
 
   @Operation(summary = "지도 화면 내 장소 마커 정보 조회 API", description = "지도 화면 내 장소 마커 정보들을 조회하는 API 입니다.")
   @GetMapping("/markers")
-  public ResponseEntity<SuccessResponse<List<ViewportMapMarkerDetail>>> getMarkersByViewport(
+  public ResponseEntity<SuccessResponse<List<MarkerResponse>>> getMarkersByViewport(
       @RequestParam Double swLat,
       @RequestParam Double swLng,
       @RequestParam Double neLat,

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/Distance.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/Distance.java
@@ -1,0 +1,13 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+public record Distance(Number value, String unit) {
+  public static Distance fromMeter(double meter) {
+    if (meter < 1000) {
+      return new Distance(Math.round(meter), "m");
+    } else {
+      double km = meter / 1000.0;
+      double roundedKm = Math.round(km * 100.0) / 100.0;
+      return new Distance(roundedKm, "km");
+    }
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/MarkerResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/MarkerResponse.java
@@ -1,0 +1,6 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MarkerResponse(Long id, Double latitude, Double longitude, String category) {}

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/RelatedSearchResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/RelatedSearchResponse.java
@@ -1,0 +1,9 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+import lombok.Builder;
+
+import com.ilta.solepli.domain.solmap.entity.SearchType;
+
+@Builder
+public record RelatedSearchResponse(
+    Long id, SearchType type, String name, String address, Distance distance, String category) {}

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/ViewportMapMarkerDetail.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/ViewportMapMarkerDetail.java
@@ -1,7 +1,0 @@
-package com.ilta.solepli.domain.solmap.dto;
-
-import lombok.Builder;
-
-@Builder
-public record ViewportMapMarkerDetail(
-    Long id, Double latitude, Double longitude, String category) {}

--- a/src/main/java/com/ilta/solepli/domain/solmap/entity/SearchType.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/entity/SearchType.java
@@ -1,0 +1,6 @@
+package com.ilta.solepli.domain.solmap.entity;
+
+public enum SearchType {
+  PLACE,
+  DISTRICT
+}

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -52,7 +52,7 @@ public class SolmapService {
   private static final int MAX_RELATED_SEARCH = 10;
 
   @Transactional(readOnly = true)
-  public List<ViewportMapMarkerDetail> getMarkersByViewport(
+  public List<MarkerResponse> getMarkersByViewport(
       Double swLat, Double swLng, Double neLat, Double neLng, String category) {
 
     // 좌표, 카테고리 유효성 검증
@@ -79,7 +79,7 @@ public class SolmapService {
     }
   }
 
-  private ViewportMapMarkerDetail toMarkerDetail(Place p, String selectedCategory) {
+  private MarkerResponse toMarkerDetail(Place p, String selectedCategory) {
     String category;
 
     if (selectedCategory != null) {
@@ -93,7 +93,7 @@ public class SolmapService {
               .orElseThrow(() -> new CustomException(ErrorCode.UNCATEGORIZED));
     }
 
-    return ViewportMapMarkerDetail.builder()
+    return MarkerResponse.builder()
         .id(p.getId())
         .latitude(p.getLatitude())
         .longitude(p.getLongitude())

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -3,6 +3,8 @@ package com.ilta.solepli.domain.solmap.service;
 import static com.ilta.solepli.global.util.OpenStatusUtil.getOpenStatus;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,7 @@ import com.ilta.solepli.domain.place.entity.mapping.PlaceCategory;
 import com.ilta.solepli.domain.place.entity.mapping.QPlaceCategory;
 import com.ilta.solepli.domain.place.repository.PlaceRepository;
 import com.ilta.solepli.domain.solmap.dto.*;
+import com.ilta.solepli.domain.solmap.entity.SearchType;
 import com.ilta.solepli.global.dto.OpenStatus;
 import com.ilta.solepli.global.exception.CustomException;
 import com.ilta.solepli.global.exception.ErrorCode;
@@ -46,6 +49,7 @@ public class SolmapService {
   private static final int MAX_RECENT_SEARCH = 10;
   private static final int TAG_LIMIT = 3;
   private static final int THUMBNAIL_LIMIT = 3;
+  private static final int MAX_RELATED_SEARCH = 10;
 
   @Transactional(readOnly = true)
   public List<ViewportMapMarkerDetail> getMarkersByViewport(
@@ -291,5 +295,98 @@ public class SolmapService {
     }
 
     return distance.gt(cursorDist).or(distance.eq(cursorDist).and(p.id.gt(cursorId)));
+  }
+
+  @Transactional(readOnly = true)
+  public List<RelatedSearchResponse> getRelatedSearch(
+      String keyword, Double userLat, Double userLng) {
+    // 구 검색 결과 스트림
+    Stream<RelatedSearchResponse> placesDistrictLike = getDistrictsByKeyword(keyword);
+    // 동 검색 결과 스트림
+    Stream<RelatedSearchResponse> placesNeighborhoodLike = getNeighborhoodsByKeyword(keyword);
+    // 장소 검색 결과 스트림 (거리순)
+    Stream<RelatedSearchResponse> placesNameLike = getPlacesByKeyword(keyword, userLat, userLng);
+
+    // 스트림을 합쳐서, 앞에서부터 MAX개만 리스트로 수집
+    return Stream.of(placesDistrictLike, placesNeighborhoodLike, placesNameLike)
+        .flatMap(Function.identity())
+        .limit(MAX_RELATED_SEARCH)
+        .toList();
+  }
+
+  /** keyword가 포함된 구 명을 중복 없이 조회하여 DTO로 매핑한 스트림을 반환. */
+  private Stream<RelatedSearchResponse> getDistrictsByKeyword(String keyword) {
+    return jpaQueryFactory
+        .select(p.district)
+        .distinct()
+        .from(p)
+        .where(p.district.contains(keyword))
+        .fetch()
+        .stream()
+        .map(s -> RelatedSearchResponse.builder().type(SearchType.DISTRICT).name(s).build());
+  }
+
+  /** keyword가 포함된 동 명을 중복 없이 조회하여 DTO로 매핑한 스트림을 반환. */
+  private Stream<RelatedSearchResponse> getNeighborhoodsByKeyword(String keyword) {
+    return jpaQueryFactory
+        .select(p.neighborhood)
+        .distinct()
+        .from(p)
+        .where(p.neighborhood.contains(keyword))
+        .fetch()
+        .stream()
+        .map(s -> RelatedSearchResponse.builder().type(SearchType.DISTRICT).name(s).build());
+  }
+
+  /** keyword가 포함된 장소를 거리순으로 조회하여 DTO로 매핑한 스트림을 반환. */
+  private Stream<RelatedSearchResponse> getPlacesByKeyword(
+      String keyword, Double userLat, Double userLng) {
+    return jpaQueryFactory
+        .select(p)
+        .from(p)
+        .join(p.placeCategories, pc)
+        .join(pc.category, c)
+        .where(p.name.contains(keyword))
+        .orderBy(distance(userLat, userLng).asc())
+        .fetch()
+        .stream()
+        .map(
+            p ->
+                RelatedSearchResponse.builder()
+                    .id(p.getId())
+                    .type(SearchType.PLACE)
+                    .name(p.getName())
+                    .address(p.getAddress())
+                    // 미터 단위 계산 후, m/km DTO로 변환
+                    .distance(
+                        Distance.fromMeter(
+                            (int)
+                                calculateDistance(
+                                    userLat, userLng, p.getLatitude(), p.getLongitude())))
+                    .category(getMainCategory(p))
+                    .build());
+  }
+
+  /** 장소에 연결된 카테고리 중 첫 번째(대표) 카테고리명을 반환. */
+  private String getMainCategory(Place place) {
+    return place.getPlaceCategories().get(0).getCategory().getName();
+  }
+
+  /** 두 위경도 좌표 간의 거리를 계산하여 미터 단위(double)로 반환. */
+  private double calculateDistance(double lat1, double lng1, double lat2, double lng2) {
+    final int EARTH_RADIUS = 6371000; // 지구 반지름 (미터 단위)
+
+    double dLat = Math.toRadians(lat2 - lat1);
+    double dLng = Math.toRadians(lng2 - lng1);
+
+    double a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2)
+            + Math.cos(Math.toRadians(lat1))
+                * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2)
+                * Math.sin(dLng / 2);
+    double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    return EARTH_RADIUS * c; // 결과: 미터(m) 단위 거리
   }
 }

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
                         "/api/auth/**",
                         "/api/solmap/markers",
                         "/api/sollect/search",
-                        "api/solmap/places")
+                        "/api/solmap/places",
+                        "/api/solmap/search/related")
                     .permitAll() // 로그인과 회원가입은 인증 없이 접근 가능
                     .anyRequest()
                     .authenticated() // 그 외 요청은 인증 필요


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#39 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠맵 연관 검색어 조회 API를 구현하였습니다.
- 구, 동, 특정 장소 순서로 최대 10개가 조회되야 하기 때문에 각 검색 결과를 스트림으로 묶은 다음 MAX_RELATE_SEARCH의 결과를 반환하도록 하였습니다.
```java
    // 구 검색 결과 스트림
    Stream<RelatedSearchResponse> placesDistrictLike = getDistrictsByKeyword(keyword);
    // 동 검색 결과 스트림
    Stream<RelatedSearchResponse> placesNeighborhoodLike = getNeighborhoodsByKeyword(keyword);
    // 장소 검색 결과 스트림 (거리순)
    Stream<RelatedSearchResponse> placesNameLike = getPlacesByKeyword(keyword, userLat, userLng);

    // 스트림을 합쳐서, 앞에서부터 MAX개만 리스트로 수집
    return Stream.of(placesDistrictLike, placesNeighborhoodLike, placesNameLike)
        .flatMap(Function.identity())
        .limit(MAX_RELATED_SEARCH)
        .toList();
``` 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
