### PR TITLE
Feat: 쏠렉트 상세 조회 기능 구현 #26

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
@@ -2,12 +2,14 @@ package com.ilta.solepli.domain.place.repository;
 
 import java.util.List;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.ilta.solepli.domain.place.entity.Place;
 
+@Primary
 public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceRepositoryCustom {
 
   @Query(

--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryCustom.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryCustom.java
@@ -2,6 +2,9 @@ package com.ilta.solepli.domain.place.repository;
 
 import java.util.List;
 
+import org.springframework.stereotype.Repository;
+
+@Repository
 public interface PlaceRepositoryCustom {
 
   List<String> getTopTagsForPlace(Long placeId, int limit);

--- a/src/main/java/com/ilta/solepli/domain/sollect/controller/SollectController.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/controller/SollectController.java
@@ -28,6 +28,7 @@ import com.ilta.solepli.domain.sollect.dto.request.KeywordRequest;
 import com.ilta.solepli.domain.sollect.dto.request.SollectCreateRequest;
 import com.ilta.solepli.domain.sollect.dto.request.SollectUpdateRequest;
 import com.ilta.solepli.domain.sollect.dto.response.SollectCreateResponse;
+import com.ilta.solepli.domain.sollect.dto.response.SollectDetailResponse;
 import com.ilta.solepli.domain.sollect.dto.response.SollectSearchResponse;
 import com.ilta.solepli.domain.sollect.service.SollectService;
 import com.ilta.solepli.domain.user.entity.User;
@@ -71,6 +72,21 @@ public class SollectController {
     sollectService.uploadSollectImage(id, files, userDetails.user());
 
     return ResponseEntity.ok().body(SuccessResponse.successWithNoData("쏠렉트 이미지 업로드 성공"));
+  }
+
+  @Operation(summary = "쏠렉트 상세 조회 API", description = "쏠렉트를 상세 조회하는 API입니다.")
+  @GetMapping("/{id}")
+  public ResponseEntity<SuccessResponse<SollectDetailResponse>> getSollectDetail(
+      @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    User user = null;
+    if (userDetails != null) {
+      user = userDetails.user();
+    }
+
+    SollectDetailResponse sollectDetail = sollectService.getSollectDetail(id, user);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(sollectDetail));
   }
 
   @Operation(summary = "쏠렉트 수정 API", description = "쏠렉트를 수정하는 API입니다.")

--- a/src/main/java/com/ilta/solepli/domain/sollect/dto/response/SollectDetailResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/dto/response/SollectDetailResponse.java
@@ -30,7 +30,7 @@ public record SollectDetailResponse(
   public record PlaceSummary(
       String name,
       String category,
-      Integer recommendationRate,
+      Integer recommendationPercent,
       List<String> tags,
       Boolean isSaved,
       Double rating) {}

--- a/src/main/java/com/ilta/solepli/domain/sollect/dto/response/SollectDetailResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/dto/response/SollectDetailResponse.java
@@ -1,0 +1,37 @@
+package com.ilta.solepli.domain.sollect.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import com.ilta.solepli.domain.sollect.entity.ContentType;
+
+@Builder
+public record SollectDetailResponse(
+    String thumbnailImageUrl,
+    String title,
+    String placeName,
+    Integer otherPlaceCount,
+    String district,
+    String neighborhood,
+    String profileImageUrl,
+    String nickname,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime createdAt,
+    List<SollectContent> contents,
+    Long savedCount,
+    List<PlaceSummary> placeSummaries) {
+  @Builder
+  public record SollectContent(ContentType type, String imageUrl, String text) {}
+
+  @Builder
+  public record PlaceSummary(
+      String name,
+      String category,
+      Integer recommendationRate,
+      List<String> tags,
+      Boolean isSaved,
+      Double rating) {}
+}

--- a/src/main/java/com/ilta/solepli/domain/sollect/entity/Sollect.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/entity/Sollect.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -48,6 +49,7 @@ public class Sollect extends Timestamped {
   private List<SollectPlace> sollectPlaces = new ArrayList<>();
 
   @OneToMany(mappedBy = "sollect", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy("seq ASC")
   @Builder.Default
   private List<SollectContent> sollectContents = new ArrayList<>();
 

--- a/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectPlaceRepository.java
@@ -1,5 +1,7 @@
 package com.ilta.solepli.domain.sollect.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +14,13 @@ public interface SollectPlaceRepository extends JpaRepository<SollectPlace, Long
   @Modifying
   @Query("DELETE FROM SollectPlace sp WHERE sp.sollect = :sollect")
   void deleteBySollect(@Param("sollect") Sollect sollect);
+
+  @Query(
+      """
+      SELECT sp FROM SollectPlace sp
+      JOIN FETCH sp.place
+      WHERE sp.sollect.id = :sollectId
+      ORDER BY sp.seq ASC
+      """)
+  List<SollectPlace> findBySollectIdWithPlace(@Param("sollectId") Long sollectId);
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepository.java
@@ -18,4 +18,15 @@ public interface SollectRepository extends JpaRepository<Sollect, Long> {
 
   @Query("select s.id from Sollect s where s.user = :user")
   List<Long> findSollectIdsByUser(@Param("user") User user);
+
+  @Query(
+      """
+  SELECT DISTINCT s FROM Sollect s
+  LEFT JOIN FETCH s.user
+  LEFT JOIN FETCH s.sollectContents
+  LEFT JOIN FETCH s.sollectPlaces sp
+  LEFT JOIN FETCH sp.place
+  WHERE s.id = :id AND s.deletedAt IS NULL
+  """)
+  Optional<Sollect> findFullSollectById(@Param("id") Long id);
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepository.java
@@ -18,15 +18,4 @@ public interface SollectRepository extends JpaRepository<Sollect, Long> {
 
   @Query("select s.id from Sollect s where s.user = :user")
   List<Long> findSollectIdsByUser(@Param("user") User user);
-
-  @Query(
-      """
-  SELECT DISTINCT s FROM Sollect s
-  LEFT JOIN FETCH s.user
-  LEFT JOIN FETCH s.sollectContents
-  LEFT JOIN FETCH s.sollectPlaces sp
-  LEFT JOIN FETCH sp.place
-  WHERE s.id = :id AND s.deletedAt IS NULL
-  """)
-  Optional<Sollect> findFullSollectById(@Param("id") Long id);
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
@@ -216,12 +216,13 @@ public class SollectService {
   public SollectDetailResponse getSollectDetail(Long id, User user) {
     Sollect sollect =
         sollectRepository
-            .findFullSollectById(id)
+            .findWithContentById(id)
             .orElseThrow(() -> new CustomException(ErrorCode.SOLLECT_NOT_FOUND));
 
     User writer = sollect.getUser();
     List<SollectContent> sollectContents = sollect.getSollectContents();
-    List<SollectPlace> sollectPlaces = sollect.getSollectPlaces();
+    List<SollectPlace> sollectPlaces =
+        sollectPlaceRepository.findBySollectIdWithPlace(sollect.getId());
 
     // 썸네일 이미지 URL
     String thumbnailImageUrl = sollectContents.get(0).getImageUrl();

--- a/src/main/java/com/ilta/solepli/domain/solmark/sollect/repository/SolmarkSollectRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/sollect/repository/SolmarkSollectRepository.java
@@ -16,4 +16,6 @@ public interface SolmarkSollectRepository extends JpaRepository<SolmarkSollect, 
   List<Long> findSollectIdsByUser(@Param("user") User user);
 
   Optional<SolmarkSollect> findBySollectAndUser(Sollect sollect, User user);
+
+  Long countSolmarkSollectsBySollect(Sollect sollect);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/sollect/service/SolmarkSollectService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/sollect/service/SolmarkSollectService.java
@@ -95,6 +95,11 @@ public class SolmarkSollectService {
     solmarkSollectRepository.delete(solmarkSollect);
   }
 
+  @Transactional(readOnly = true)
+  public Long getSavedCount(Sollect sollect) {
+    return solmarkSollectRepository.countSolmarkSollectsBySollect(sollect);
+  }
+
   private List<SolmarkSollectResponse.SollectSearchContent> toResponseContent(
       List<SolmarkSollectResponseContent> contents) {
     return contents.stream()

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -49,7 +50,9 @@ public class SecurityConfig {
                         "/api/sollect/search",
                         "/api/solmap/places",
                         "/api/solmap/search/related")
-                    .permitAll() // 로그인과 회원가입은 인증 없이 접근 가능
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/sollect/*")
+                    .permitAll()
                     .anyRequest()
                     .authenticated() // 그 외 요청은 인증 필요
             )


### PR DESCRIPTION
## #️⃣ Issue Number
#26 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
## 쏠렉트 상세 조회 기능 구현
### 조회 대상
- Sollect
- Sollect.user (작성자)
- Sollect.sollectContents (콘텐츠)
- Sollect.sollectPlaces + Place (장소)
### 쏠렉트 + 쏠렉트 컨텐츠 + 유저
```
Sollect sollect =
        sollectRepository
            .findWithContentById(id)
            .orElseThrow(() -> new CustomException(ErrorCode.SOLLECT_NOT_FOUND));
```
```
@EntityGraph(attributePaths = {"user", "sollectContents"})
  @Query("SELECT s FROM Sollect s WHERE s.id = :id AND s.deletedAt IS NULL")
  Optional<Sollect> findWithContentById(@Param("id") Long id);
```
```
User writer = sollect.getUser();
List<SollectContent> sollectContents = sollect.getSollectContents();
```
@EntityGraph를 활용했습니다!

### 쏠렉트 장소
```
List<SollectPlace> sollectPlaces =
    sollectPlaceRepository.findBySollectIdWithPlace(sollect.getId());
```
```
@Query(
      """
      SELECT sp FROM SollectPlace sp
      JOIN FETCH sp.place
      WHERE sp.sollect.id = :sollectId
      ORDER BY sp.seq ASC
      """)
  List<SollectPlace> findBySollectIdWithPlace(@Param("sollectId") Long sollectId);
```

Fetch Join + 쿼리 분리 방식으로 N+1 문제 방지했습니다!

그리고 `SollectDetailResponse.PlaceSummary`의 `isSaved` 필드는 추후에 쏠마크 - 장소 기능이 구현되면 추가할 예정입니다.


<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가