### PR TITLE
Feat: 지역 검색 마커 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
@@ -2,7 +2,6 @@ package com.ilta.solepli.domain.place.repository;
 
 import java.util.List;
 
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,7 +25,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
       @Param("neLng") Double neLng,
       @Param("category") String category);
 
-  @EntityGraph(attributePaths = {"placeCategories", "placeCategories.category"})
   @Query(
       "SELECT DISTINCT  p "
           + "FROM Place p "

--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
@@ -2,14 +2,13 @@ package com.ilta.solepli.domain.place.repository;
 
 import java.util.List;
 
-import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.ilta.solepli.domain.place.entity.Place;
 
-@Primary
 public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceRepositoryCustom {
 
   @Query(
@@ -26,4 +25,13 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
       @Param("neLat") Double neLat,
       @Param("neLng") Double neLng,
       @Param("category") String category);
+
+  @EntityGraph(attributePaths = {"placeCategories", "placeCategories.category"})
+  @Query(
+      "SELECT DISTINCT  p "
+          + "FROM Place p "
+          + "JOIN FETCH p.placeCategories pc "
+          + "JOIN FETCH pc.category c "
+          + "WHERE p.district = :regionName OR p.neighborhood = :regionName")
+  List<Place> findAllByRegionName(@Param("regionName") String regionName);
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
@@ -18,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 
 import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.place.repository.PlaceRepository;
-import com.ilta.solepli.domain.place.repository.PlaceRepositoryCustom;
 import com.ilta.solepli.domain.sollect.dto.SollectSearchResponseContent;
 import com.ilta.solepli.domain.sollect.dto.request.SollectCreateRequest;
 import com.ilta.solepli.domain.sollect.dto.request.SollectUpdateRequest;
@@ -53,7 +52,6 @@ public class SollectService {
   private final RedisTemplate<String, Object> redisTemplate;
   private final SollectRepositoryCustom sollectRepositoryCustom;
   private final SolmarkSollectRepository solmarkSollectRepository;
-  private final PlaceRepositoryCustom placeRepositoryCustom;
 
   private static final String RECENT_SEARCH_PREFIX = "sollect_recent_search:";
   private static final int MAX_RECENT_SEARCH = 10;
@@ -264,8 +262,8 @@ public class SollectService {
     List<SollectDetailResponse.PlaceSummary> placeSummaries = new ArrayList<>();
     for (SollectPlace sollectPlace : sollectPlaces) {
       Place place = sollectPlace.getPlace();
-      List<String> tags = placeRepositoryCustom.getTopTagsForPlace(place.getId(), 3);
-      Integer recommendationPercent = placeRepositoryCustom.getRecommendationPercent(place.getId());
+      List<String> tags = placeRepository.getTopTagsForPlace(place.getId(), 3);
+      Integer recommendationPercent = placeRepository.getRecommendationPercent(place.getId());
 
       SollectDetailResponse.PlaceSummary placeSummary =
           SollectDetailResponse.PlaceSummary.builder()
@@ -404,12 +402,12 @@ public class SollectService {
 
   @Transactional(readOnly = true)
   public List<PlaceSearchResponse> getSearchPlaces(String keyword) {
-    return placeRepositoryCustom.getPlacesByKeyword(keyword);
+    return placeRepository.getPlacesByKeyword(keyword);
   }
 
   @Transactional(readOnly = true)
   public SollectPlaceAddPreviewResponse getPlacePreview(Long placeId) {
-    return placeRepositoryCustom.getSollectAddPreview(placeId);
+    return placeRepository.getSollectAddPreview(placeId);
   }
 
   private SollectContent findImage(List<SollectContent> sollectContents, String filename) {

--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -109,4 +109,14 @@ public class SolmapController {
 
     return ResponseEntity.ok(SuccessResponse.successWithData(response));
   }
+
+  @Operation(summary = "지역 검색 마커 정보 조회 API", description = "지역 검색 카머 정보 조회 aPI 입니다.")
+  @GetMapping("/region/{regionName}/markers")
+  public ResponseEntity<SuccessResponse<List<MarkerResponse>>> getMarkersByRegion(
+      @PathVariable String regionName) {
+
+    List<MarkerResponse> response = solmapService.getMarkersByRegion(regionName);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -110,7 +110,7 @@ public class SolmapController {
     return ResponseEntity.ok(SuccessResponse.successWithData(response));
   }
 
-  @Operation(summary = "지역 검색 마커 정보 조회 API", description = "지역 검색 카머 정보 조회 aPI 입니다.")
+  @Operation(summary = "지역 검색 마커 정보 조회 API", description = "지역 검색 마커 정보 조회 API 입니다.")
   @GetMapping("/region/{regionName}/markers")
   public ResponseEntity<SuccessResponse<List<MarkerResponse>>> getMarkersByRegion(
       @PathVariable String regionName) {

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -389,4 +389,26 @@ public class SolmapService {
 
     return EARTH_RADIUS * c; // 결과: 미터(m) 단위 거리
   }
+
+  public List<MarkerResponse> getMarkersByRegion(String regionName) {
+    // regionName과 동일한 구, 동 장소 조회
+    return getMarkerByRegion(regionName);
+  }
+
+  private List<MarkerResponse> getMarkerByRegion(String regionName) {
+    // 조회된 각 장소를 DTO 변환
+    return placeRepository.findAllByRegionName(regionName).stream()
+        .map(this::getMarkerResponse)
+        .toList();
+  }
+
+  private MarkerResponse getMarkerResponse(Place p) {
+    // 응답 DTO 변환
+    return MarkerResponse.builder()
+        .id(p.getId())
+        .latitude(p.getLatitude())
+        .longitude(p.getLongitude())
+        .category(getMainCategory(p))
+        .build();
+  }
 }

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                         "/api/sollect/search",
                         "/api/solmap/places",
                         "/api/solmap/search/related",
+                        "/api/sollect/search/place/**",
                         "/api/solmap/region/*/markers")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/sollect/*")

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                         "/api/sollect/search",
                         "/api/solmap/places",
                         "/api/solmap/search/related",
-                        "/api/sollect/search/place/**")
+                        "/api/solmap/region/*/markers")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/sollect/*")
                     .permitAll()


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#43 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 지역 검색 마커 정보 조회 API를 구현하였습니다.
- 지역검색으로 조회된 장소를 카테고리도 조회시 N + 1방지를 위한 Fetch join 사용
```java
  @EntityGraph(attributePaths = {"placeCategories", "placeCategories.category"})
  @Query(
      "SELECT DISTINCT  p "
          + "FROM Place p "
          + "JOIN FETCH p.placeCategories pc "
          + "JOIN FETCH pc.category c "
          + "WHERE p.district = :regionName OR p.neighborhood = :regionName")
  List<Place> findAllByRegionName(@Param("regionName") String regionName);
``` 


- PlaceCustomRepository -> placeRepository로 변경하였습니다.
![image](https://github.com/user-attachments/assets/b842f109-13dc-4502-828d-070cbed2ec4a)



## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 버그 수정
