### PR TITLE
Feat: 지역 검색 장소 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
@@ -32,4 +32,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
           + "JOIN FETCH pc.category c "
           + "WHERE p.district = :regionName OR p.neighborhood = :regionName")
   List<Place> findAllByRegionName(@Param("regionName") String regionName);
+
+  Boolean existsByDistrictOrNeighborhood(String district, String neighborhood);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -119,4 +119,22 @@ public class SolmapController {
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
+
+  @Operation(summary = "지역 검색 장소 리스트 조회 API", description = "지역 검색 장소 리스트 조회 API 입니다.")
+  @GetMapping("/region/{regionName}/places")
+  public ResponseEntity<SuccessResponse<PlaceSearchPreviewResponse>> getPlacesByRegionPreview(
+      @PathVariable String regionName,
+      @RequestParam Double userLat,
+      @RequestParam Double userLng,
+      @RequestParam(required = false) String category,
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(required = false) Double cursorDist,
+      @RequestParam(required = false, defaultValue = "5") int limit) {
+
+    PlaceSearchPreviewResponse response =
+        solmapService.getPlacesByRegionPreview(
+            regionName, userLat, userLng, category, cursorId, cursorDist, limit);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -87,7 +87,7 @@ public class SolmapController {
       @RequestParam Double neLng,
       @RequestParam Double userLat,
       @RequestParam Double userLng,
-      @RequestParam String category,
+      @RequestParam(required = false) String category,
       @RequestParam(required = false) Long cursorId,
       @RequestParam(required = false) Double cursorDist,
       @RequestParam(required = false, defaultValue = "5") int limit) {

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/CursorInfo.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/CursorInfo.java
@@ -1,0 +1,7 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+public record CursorInfo(Long id, Double distance) {
+  public static CursorInfo of(Long id, Double distance) {
+    return new CursorInfo(id, distance);
+  }
+}

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
                         "/api/solmap/places",
                         "/api/solmap/search/related",
                         "/api/sollect/search/place/**",
-                        "/api/solmap/region/*/markers")
+                        "/api/solmap/region/*/markers",
+                        "/api/solmap/region/*/places")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/sollect/*")
                     .permitAll()

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -63,7 +63,8 @@ public enum ErrorCode {
   // 쏠맵 기능 관련 에러
   INVALID_VIEWPORT_COORDINATES(HttpStatus.BAD_REQUEST, "SW 좌표는 NE 좌표보다 작아야 합니다."),
   CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다."),
-  UNCATEGORIZED(HttpStatus.OK, "카테고리가 지정되지 않은 장소입니다."),
+  UNCATEGORIZED(HttpStatus.BAD_REQUEST, "카테고리가 지정되지 않은 장소입니다."),
+  REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 지역명 입니다."),
 
   // 쏠렉트 관련 에러
   SOLLECT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 쏠렉트입니다."),


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#47 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 지역 검색 장소 리스트 조회 기능 API를 구현하였습니다.
- 이전에 개발한 지도 화면 내에 속한 장소 리스트 조회 API의 코드에서 장소 조회시 지역이름으로 필터링하는 부분 regionNameIn 메서도로 추가하였습니다.
- 나머지 코드는 비슷하되 각 기능별로 메서드로 나눴습니다.
```java
  private List<Place> fetchPlacesByRegionAndCursor(
      Double userLat,
      Double userLng,
      String regionName,
      String category,
      Long cursorId,
      Double cursorDist,
      int limit) {

    // 거리 계산용 표현식 생성 (Haversine 공식)
    NumberExpression<Double> distance = distance(userLat, userLng);

    return jpaQueryFactory
        .selectFrom(p)
        .distinct()
        .leftJoin(p.placeCategories, pc)
        .leftJoin(pc.category, c)
        .leftJoin(p.placeHours, ph)
        .where(
            regionNameIn(regionName), // <-- 지역이름으로 필터링 추가
            categoryIn(category),
            cursorAfter(cursorId, cursorDist, distance))
        .orderBy(distance.asc(), p.id.asc())
        .limit(limit + 1) // 커서 페이징을 위해 limit+1개 조회 (limit개 + nextCursor용 1개)
        .fetch();
  }
``` 
- 추후에 이전에 개발한 지도 화면 내에 속한 장소 리스트 조회 API도 리펙토링할 예정입니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
