### PR TITLE
Feat: 인기 쏠렉트 조회 기능 구현 (#50)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/sollect/controller/SollectController.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/controller/SollectController.java
@@ -183,4 +183,20 @@ public class SollectController {
 
     return ResponseEntity.ok(SuccessResponse.successWithData(placePreview));
   }
+
+  @Operation(summary = "인기 쏠렉트 조회 API", description = "인기(저장 수가 많은) 쏠렉트를 조회하는 API 입니다.")
+  @GetMapping("/popular")
+  public ResponseEntity<SuccessResponse<List<SollectSearchResponse.SollectSearchContent>>>
+      getPopularSollects(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+    User user = null;
+    if (customUserDetails != null) {
+      user = customUserDetails.user();
+    }
+
+    List<SollectSearchResponse.SollectSearchContent> popularSollects =
+        sollectService.getPopularSollects(user);
+
+    return ResponseEntity.ok(SuccessResponse.successWithData(popularSollects));
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryCustom.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryCustom.java
@@ -14,4 +14,6 @@ public interface SollectRepositoryCustom {
 
   List<SolmarkSollectResponseContent> searchBySolmarkSollect(
       Long cursorId, int size, List<Long> sollectIds);
+
+  List<SollectSearchResponseContent> searchSollectBySollectIds(List<Long> sollectIds);
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryImpl.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryImpl.java
@@ -118,6 +118,29 @@ public class SollectRepositoryImpl implements SollectRepositoryCustom {
         .fetch();
   }
 
+  @Override
+  public List<SollectSearchResponseContent> searchSollectBySollectIds(List<Long> sollectIds) {
+    QSollectPlace firstPlace = new QSollectPlace("firstPlace");
+    QPlace firstPlaceInfo = new QPlace("firstPlaceInfo");
+
+    return queryFactory
+        .select(
+            new QSollectSearchResponseContent(
+                sollect.id,
+                sollectContent.imageUrl,
+                sollect.title,
+                firstPlaceInfo.district,
+                firstPlaceInfo.neighborhood))
+        .from(sollect)
+        .join(sollect.sollectPlaces, firstPlace)
+        .on(firstPlace.seq.eq(0))
+        .join(firstPlace.place, firstPlaceInfo)
+        .join(sollect.sollectContents, sollectContent)
+        .on(sollectContent.seq.eq(0L))
+        .where(sollect.id.in(sollectIds))
+        .fetch();
+  }
+
   private BooleanExpression anyMatchKeyword(String keyword) {
     if (keyword == null || keyword.isBlank()) return null;
     return place

--- a/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
@@ -35,6 +35,7 @@ import com.ilta.solepli.domain.sollect.repository.SollectPlaceRepository;
 import com.ilta.solepli.domain.sollect.repository.SollectRepository;
 import com.ilta.solepli.domain.sollect.repository.SollectRepositoryCustom;
 import com.ilta.solepli.domain.solmark.sollect.repository.SolmarkSollectRepository;
+import com.ilta.solepli.domain.solmark.sollect.service.SolmarkSollectService;
 import com.ilta.solepli.domain.user.entity.User;
 import com.ilta.solepli.global.exception.CustomException;
 import com.ilta.solepli.global.exception.ErrorCode;
@@ -52,9 +53,11 @@ public class SollectService {
   private final RedisTemplate<String, Object> redisTemplate;
   private final SollectRepositoryCustom sollectRepositoryCustom;
   private final SolmarkSollectRepository solmarkSollectRepository;
+  private final SolmarkSollectService solmarkSollectService;
 
   private static final String RECENT_SEARCH_PREFIX = "sollect_recent_search:";
   private static final int MAX_RECENT_SEARCH = 10;
+  private static final int POPULAR_SEARCH_LIMIT = 4;
 
   @Transactional
   public SollectCreateResponse createSollect(SollectCreateRequest request, User user) {
@@ -408,6 +411,22 @@ public class SollectService {
   @Transactional(readOnly = true)
   public SollectPlaceAddPreviewResponse getPlacePreview(Long placeId) {
     return placeRepository.getSollectAddPreview(placeId);
+  }
+
+  @Transactional(readOnly = true)
+  public List<SollectSearchResponse.SollectSearchContent> getPopularSollects(User user) {
+    // 저장 수가 많은 limit개 Sollect ID들
+    List<Long> sollectIds = solmarkSollectService.getPopularSollectIds(POPULAR_SEARCH_LIMIT);
+    // DTO 변환
+    List<SollectSearchResponseContent> rawContents =
+        sollectRepositoryCustom.searchSollectBySollectIds(sollectIds);
+    // 해당 유저의 쏠렉트 저장여부 알기 위해
+    Set<Long> markedSet =
+        (user == null)
+            ? Collections.emptySet()
+            : new HashSet<>(solmarkSollectRepository.findSollectIdsByUser(user));
+
+    return toResponseContent(rawContents, markedSet);
   }
 
   private SollectContent findImage(List<SollectContent> sollectContents, String filename) {

--- a/src/main/java/com/ilta/solepli/domain/solmark/sollect/repository/SolmarkSollectRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/sollect/repository/SolmarkSollectRepository.java
@@ -3,6 +3,7 @@ package com.ilta.solepli.domain.solmark.sollect.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +19,11 @@ public interface SolmarkSollectRepository extends JpaRepository<SolmarkSollect, 
   Optional<SolmarkSollect> findBySollectAndUser(Sollect sollect, User user);
 
   Long countSolmarkSollectsBySollect(Sollect sollect);
+
+  @Query(
+      "SELECT s.sollect.id "
+          + "FROM SolmarkSollect s "
+          + "GROUP BY s.sollect.id "
+          + "ORDER BY COUNT(s) DESC")
+  List<Long> findPopularSollectIds(Pageable pageable);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/sollect/repository/SolmarkSollectRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/sollect/repository/SolmarkSollectRepository.java
@@ -26,4 +26,6 @@ public interface SolmarkSollectRepository extends JpaRepository<SolmarkSollect, 
           + "GROUP BY s.sollect.id "
           + "ORDER BY COUNT(s) DESC")
   List<Long> findPopularSollectIds(Pageable pageable);
+
+  boolean existsBySollectIdAndUser(Long sollectId, User user);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/sollect/service/SolmarkSollectService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/sollect/service/SolmarkSollectService.java
@@ -2,6 +2,7 @@ package com.ilta.solepli.domain.solmark.sollect.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -98,6 +99,11 @@ public class SolmarkSollectService {
   @Transactional(readOnly = true)
   public Long getSavedCount(Sollect sollect) {
     return solmarkSollectRepository.countSolmarkSollectsBySollect(sollect);
+  }
+
+  @Transactional(readOnly = true)
+  public List<Long> getPopularSollectIds(int limit) {
+    return solmarkSollectRepository.findPopularSollectIds(PageRequest.of(0, limit));
   }
 
   private List<SolmarkSollectResponse.SollectSearchContent> toResponseContent(

--- a/src/main/java/com/ilta/solepli/domain/solmark/sollect/service/SolmarkSollectService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/sollect/service/SolmarkSollectService.java
@@ -34,6 +34,10 @@ public class SolmarkSollectService {
             .findById(id)
             .orElseThrow(() -> new CustomException(ErrorCode.SOLLECT_NOT_FOUND));
 
+    if (solmarkSollectRepository.existsBySollectIdAndUser(id, user)) {
+      throw new CustomException(ErrorCode.SOLMARK_SOLLECT_EXISTS);
+    }
+
     SolmarkSollect solmarkSollect = SolmarkSollect.builder().sollect(sollect).user(user).build();
 
     solmarkSollectRepository.save(solmarkSollect);

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -69,6 +69,7 @@ public enum ErrorCode {
   // 쏠렉트 관련 에러
   SOLLECT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 쏠렉트입니다."),
   SOLMARK_SOLLECT_NOT_FOUND(HttpStatus.NOT_FOUND, "쏠마크되지 않은 쏠렉트입니다."),
+  SOLMARK_SOLLECT_EXISTS(HttpStatus.BAD_REQUEST, "이미 쏠마크한 쏠렉트입니다."),
   SOLLECT_FORBIDDEN(HttpStatus.FORBIDDEN, "쏠렉트의 소유자가 아닙니다."),
   TOO_MANY_SOLLECT_IMAGES(HttpStatus.BAD_REQUEST, "쏠렉트 사진은 최대 100장까지 가능합니다."),
   CONTENT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 콘텐츠 이미지를 찾을 수 없습니다."),


### PR DESCRIPTION
## #️⃣ Issue Number
#50
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
인기 쏠렉트 조회 기능 구현 완료했습니다.
```
@Query(
      "SELECT s.sollect.id "
          + "FROM SolmarkSollect s "
          + "GROUP BY s.sollect.id "
          + "ORDER BY COUNT(s) DESC")
  List<Long> findPopularSollectIds(Pageable pageable);
```
JPA에서 limit을 직접 사용할 수 없어서 Pageable을 이용해 저장 수가 많은 limit개의 sollectId를 가져오고,
```
@Override
  public List<SollectSearchResponseContent> searchSollectBySollectIds(List<Long> sollectIds) {
    QSollectPlace firstPlace = new QSollectPlace("firstPlace");
    QPlace firstPlaceInfo = new QPlace("firstPlaceInfo");

    return queryFactory
        .select(
            new QSollectSearchResponseContent(
                sollect.id,
                sollectContent.imageUrl,
                sollect.title,
                firstPlaceInfo.district,
                firstPlaceInfo.neighborhood))
        .from(sollect)
        .join(sollect.sollectPlaces, firstPlace)
        .on(firstPlace.seq.eq(0))
        .join(firstPlace.place, firstPlaceInfo)
        .join(sollect.sollectContents, sollectContent)
        .on(sollectContent.seq.eq(0L))
        .where(sollect.id.in(sollectIds))
        .fetch();
  } 
```
Query Projection을 이용해 DTO 변환을 처리했습니다.

`sollect.id.in(sollectIds)`는 인기순 ID로 조회는 되지만,
순서 보장은 안 되므로
```
Map<Long, SollectSearchResponseContent> contentMap =
        rawContents.stream()
            .collect(Collectors.toMap(SollectSearchResponseContent::sollectId, c -> c));

    List<SollectSearchResponseContent> sortedContents =
        sollectIds.stream()
            .map(contentMap::get)
            .filter(Objects::nonNull) // 혹시 없는 경우 대비
            .collect(Collectors.toList());
```
Map과 Stream을 이용하여 순서를 보장하였습니다.


<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
