### PR TITLE
Feat: 장소 상세 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
@@ -1,6 +1,7 @@
 package com.ilta.solepli.domain.place.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -34,4 +35,12 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
   List<Place> findAllByRegionName(@Param("regionName") String regionName);
 
   Boolean existsByDistrictOrNeighborhood(String district, String neighborhood);
+
+  @Query(
+      "SELECT p "
+          + "FROM Place p "
+          + "JOIN FETCH p.placeCategories pc "
+          + "JOIN FETCH pc.category c "
+          + "WHERE p.id = :id")
+  Optional<Place> findByPlaceId(@Param("id") Long id);
 }

--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.ilta.solepli.domain.place.repository;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -57,8 +57,10 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
             .fetch();
 
     return reviews.stream()
-        .map(r -> r.getReviewImages().stream().findFirst().map(ReviewImage::getImageUrl))
-        .map(Optional::toString)
+        .map(
+            r ->
+                r.getReviewImages().stream().findFirst().map(ReviewImage::getImageUrl).orElse(null))
+        .filter(Objects::nonNull)
         .toList();
   }
 

--- a/src/main/java/com/ilta/solepli/domain/review/entity/Review.java
+++ b/src/main/java/com/ilta/solepli/domain/review/entity/Review.java
@@ -19,6 +19,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -64,5 +65,6 @@ public class Review extends Timestamped {
 
   @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
+  @BatchSize(size = 10)
   private List<ReviewTag> reviewTags = new ArrayList<>();
 }

--- a/src/main/java/com/ilta/solepli/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/review/repository/ReviewRepository.java
@@ -1,5 +1,8 @@
 package com.ilta.solepli.domain.review.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +16,15 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   Double findAverageRatingByPlaceId(@Param("placeId") Long placeId);
 
   boolean existsByUserAndPlace(User user, Place place);
+
+  @Query(
+      """
+                      SELECT r
+                      FROM Review r
+                      JOIN FETCH r.user u
+                      JOIN FETCH r.reviewImages ri
+                      WHERE r.place.id = :placeId
+                      ORDER BY r.createdAt DESC
+                  """)
+  List<Review> findByWithImagesAndUserByPlaceId(@Param("placeId") Long placeId, Pageable pageable);
 }

--- a/src/main/java/com/ilta/solepli/domain/review/repository/ReviewTagCustomRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/review/repository/ReviewTagCustomRepository.java
@@ -1,0 +1,28 @@
+package com.ilta.solepli.domain.review.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.ilta.solepli.domain.review.entity.mapping.ReviewTag;
+import com.ilta.solepli.domain.solmap.dto.TagInfo;
+import com.ilta.solepli.domain.tag.entity.TagType;
+
+@Repository
+public interface ReviewTagCustomRepository extends JpaRepository<ReviewTag, Long> {
+
+  @Query(
+      """
+            SELECT new com.ilta.solepli.domain.solmap.dto.TagInfo(rt.name, COUNT(rt))
+            FROM ReviewTag rt
+            JOIN rt.review r
+            WHERE r.place.id = :placeId AND rt.tagType = :tagType
+            GROUP BY rt.name
+            ORDER BY COUNT(rt) DESC
+            """)
+  List<TagInfo> findTagCountsByPlaceAndType(
+      @Param("placeId") Long placeId, @Param("tagType") TagType tagType);
+}

--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import com.ilta.solepli.domain.solmap.dto.KeywordRequest;
-import com.ilta.solepli.domain.solmap.dto.MarkerResponse;
-import com.ilta.solepli.domain.solmap.dto.PlaceSearchPreviewResponse;
-import com.ilta.solepli.domain.solmap.dto.RelatedSearchResponse;
+import com.ilta.solepli.domain.solmap.dto.*;
 import com.ilta.solepli.domain.solmap.service.SolmapService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
 import com.ilta.solepli.global.response.SuccessResponse;
@@ -134,6 +131,16 @@ public class SolmapController {
     PlaceSearchPreviewResponse response =
         solmapService.getPlacesByRegionPreview(
             regionName, userLat, userLng, category, cursorId, cursorDist, limit);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+  }
+
+  @Operation(summary = "장소 상세정보 조회 API", description = "장소 상세정보 조회 API 입니다.")
+  @GetMapping("/place/search/{id}")
+  public ResponseEntity<SuccessResponse<PlaceDetailSearchResponse>> getPlaceDetail(
+      @PathVariable Long id) {
+
+    PlaceDetailSearchResponse response = solmapService.getPlaceDetail(id);
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/OpeningHour.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/OpeningHour.java
@@ -1,0 +1,12 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+import java.time.LocalTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+@Builder
+public record OpeningHour(
+    Integer dayOfWeek,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime startTime,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime endTime) {}

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/PlaceDetail.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/PlaceDetail.java
@@ -1,0 +1,24 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+@Builder
+public record PlaceDetail(
+    Long id,
+    String name,
+    String category,
+    String detailedCategory,
+    Double latitude,
+    Double longitude,
+    Boolean isOpen,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime closingTime,
+    List<OpeningHour> openingHours,
+    String address,
+    PlaceTags tags,
+    Integer isSoloRecommended,
+    Double rating,
+    List<String> thumbnailUrl) {}

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/PlaceDetailSearchResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/PlaceDetailSearchResponse.java
@@ -1,0 +1,9 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+import java.util.List;
+
+public record PlaceDetailSearchResponse(PlaceDetail place, List<ReviewDetail> reviews) {
+  public static PlaceDetailSearchResponse of(PlaceDetail place, List<ReviewDetail> reviews) {
+    return new PlaceDetailSearchResponse(place, reviews);
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/PlaceTags.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/PlaceTags.java
@@ -1,0 +1,9 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+import java.util.List;
+
+public record PlaceTags(List<TagInfo> mood, List<TagInfo> solo) {
+  public static PlaceTags of(List<TagInfo> mood, List<TagInfo> solo) {
+    return new PlaceTags(mood, solo);
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/ReviewDetail.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/ReviewDetail.java
@@ -1,0 +1,17 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewDetail(
+    String userProfileUrl,
+    String userNickname,
+    LocalDateTime createdAt,
+    Boolean isRecommended,
+    Double rating,
+    String content,
+    List<String> photoUrls,
+    List<String> tags) {}

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/TagInfo.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/TagInfo.java
@@ -1,0 +1,7 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+public record TagInfo(String tagName, long tagTotal) {
+  public static TagInfo of(String tagName, long tagTotal) {
+    return new TagInfo(tagName, tagTotal);
+  }
+}

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -52,7 +52,8 @@ public class SecurityConfig {
                         "/api/solmap/search/related",
                         "/api/sollect/search/place/**",
                         "/api/solmap/region/*/markers",
-                        "/api/solmap/region/*/places")
+                        "/api/solmap/region/*/places",
+                        "/api/solmap/place/search/*")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/sollect/*")
                     .permitAll()


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#47 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 장소 상세 정보 조회 API를 개발하였습니다.

- tagType(MOOD, SOLO)을 기준으로 가장 많이 선택된 태그 이름순으로 태그 이름과 선택빈도를 반환하도록 하는 메서드
```java
  @Query(
      """
            SELECT new com.ilta.solepli.domain.solmap.dto.TagInfo(rt.name, COUNT(rt))
            FROM ReviewTag rt
            JOIN rt.review r
            WHERE r.place.id = :placeId AND rt.tagType = :tagType
            GROUP BY rt.name
            ORDER BY COUNT(rt) DESC
            """)
  List<TagInfo> findTagCountsByPlaceAndType(
      @Param("placeId") Long placeId, @Param("tagType") TagType tagType);
``` 

- 리뷰 엔티티에서 reviewImages와 reviewTags 2개 모두 컬렉션이어서 2개 모두 FETCH JOIN이 불가능합니다. 그래서 reviewImages만 FETCH JOIN을 걸고 reviewTags에는 @BatchSize를 추가하여 지연로딩을 하되 최대 10개의 Review 엔티티에 달린 reviewTags를 IN절(batch)로 묶어서 한 번에 조회하도록 하였습니다.

```java
  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
  @Builder.Default
  @BatchSize(size = 10)
  private List<ReviewTag> reviewTags = new ArrayList<>();
``` 
```java
  @Query(
      """
                      SELECT r
                      FROM Review r
                      JOIN FETCH r.user u
                      JOIN FETCH r.reviewImages ri
                      WHERE r.place.id = :placeId
                      ORDER BY r.createdAt DESC
                  """)
  List<Review> findByWithImagesAndUserByPlaceId(@Param("placeId") Long placeId, Pageable pageable);
``` 




## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
