### PR TITLE
Feat: 쏠맵 연관 검색어 결과 장소 마커 정보 및 장소 프리뷰 조회 기능 구현 (#55)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepository.java
@@ -43,4 +43,14 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
           + "JOIN FETCH pc.category c "
           + "WHERE p.id = :id")
   Optional<Place> findByPlaceId(@Param("id") Long id);
+
+  @Query(
+      """
+    SELECT p
+    FROM Place p
+    JOIN FETCH p.placeCategories pc
+    JOIN FETCH pc.category c
+    WHERE p.id IN :ids
+""")
+  List<Place> findByPlace_IdIn(List<Long> ids);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -160,4 +160,17 @@ public class SolmapController {
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
+
+  @Operation(summary = "연관 검색어 결과 장소 리스트 조회 API", description = "연관 검색어 결과 장소 리스트 조회 API 입니다.")
+  @GetMapping("/places/search/related")
+  public ResponseEntity<SuccessResponse<PlaceSearchPreviewResponse>> getPlacePreviewByRelatedSearch(
+      @RequestParam List<Long> ids,
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(required = false, defaultValue = "5") int limit) {
+
+    PlaceSearchPreviewResponse response =
+        solmapService.getPlacePreviewByRelatedSearch(ids, cursorId, limit);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -150,4 +150,14 @@ public class SolmapController {
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
+
+  @Operation(summary = "연관 검색어 결과 장소 마커 정보 조회 API", description = "연관 검색어 결과 장소 마커 정보 조회 API 입니다.")
+  @GetMapping("/markers/search/related")
+  public ResponseEntity<SuccessResponse<List<MarkerResponse>>> getMarkersByRelatedSearch(
+      @RequestParam List<Long> ids, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+    List<MarkerResponse> response = solmapService.getMarkersByRelatedSearch(ids, customUserDetails);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -704,6 +704,7 @@ public class SolmapService {
         .toList();
   }
 
+  @Transactional(readOnly = true)
   public List<MarkerResponse> getMarkersByRelatedSearch(
       List<Long> ids, CustomUserDetails customUserDetails) {
     // 사용자 로그인, 비로그인 판별

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -716,4 +716,43 @@ public class SolmapService {
 
     return places.stream().map(p -> getMarkerResponse(p, solmarkedPlaceIds)).toList();
   }
+
+  @Transactional(readOnly = true)
+  public PlaceSearchPreviewResponse getPlacePreviewByRelatedSearch(
+      List<Long> ids, Long cursorId, int limit) {
+
+    // 커서 기준으로 시작 인덱스 계산 (없으면 0)
+    int startIdx = 0;
+    if (cursorId != null) {
+      int idx = ids.indexOf(cursorId);
+      // cursorId가 ids에 없을 때 -1이 반환됨 -> 그 경우 startIdx는 0 유지
+      if (idx != -1) {
+        startIdx = idx + 1;
+      }
+    }
+    // limit만큼 끝 인덱스 계산 (리스트 범위 초과 방지)
+    int endIdx = Math.min(startIdx + limit, ids.size());
+
+    // 현재 페이지에 해당하는 placeId만 추출
+    List<Long> placeIds = ids.subList(startIdx, endIdx);
+
+    // placeId로 Place 조회 (순서 보장 X)
+    List<Place> places = placeRepository.findByPlace_IdIn(placeIds);
+
+    // 조회 결과를 placeIds 순서대로 정렬
+    Map<Long, Place> placeMap =
+        places.stream().collect(Collectors.toMap(Place::getId, Function.identity()));
+    List<Place> orderedPlaces = placeIds.stream().map(placeMap::get).toList();
+
+    // PlacePreviewDetail DTO로 매핑
+    List<PlacePreviewDetail> placePreviewDetails = mapToPreviewDetails(orderedPlaces, limit);
+
+    // 더 불러올 데이터가 있으면 다음 커서 id, 없으면 null
+    Long nextCursor = (endIdx < ids.size()) ? ids.get(endIdx - 1) : null;
+
+    return PlaceSearchPreviewResponse.builder()
+        .places(placePreviewDetails)
+        .nextCursor(nextCursor)
+        .build();
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -703,4 +703,17 @@ public class SolmapService {
                     .build())
         .toList();
   }
+
+  public List<MarkerResponse> getMarkersByRelatedSearch(
+      List<Long> ids, CustomUserDetails customUserDetails) {
+    // 사용자 로그인, 비로그인 판별
+    User user = SecurityUtil.getUser(customUserDetails);
+
+    List<Place> places = placeRepository.findByPlace_IdIn(ids);
+
+    // 쏠마크한 PlaceId 리스트 조회
+    Set<Long> solmarkedPlaceIds = getSolmarkedPlaceIds(user, places);
+
+    return places.stream().map(p -> getMarkerResponse(p, solmarkedPlaceIds)).toList();
+  }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#55 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠맵 연관검색어에서 조회되는 장소들의 마커 정보와 장소 프리뷰 정보를 조회하는 기능을 구현하였습니다.
- 파라미터로 받은 장소 id 리스트를 findByPlace_IdIn 메서드로 장소 엔티티를 조회하는데 순서가 보장되지 않아서 아래와 같이 순서대로 재 정렬하였습니다.


```java
  @Query(
      """
    SELECT p
    FROM Place p
    JOIN FETCH p.placeCategories pc
    JOIN FETCH pc.category c
    WHERE p.id IN :ids
""")
  List<Place> findByPlace_IdIn(List<Long> ids);
``` 

```java
    // placeId로 Place 조회 (순서 보장 X)
    List<Place> places = placeRepository.findByPlace_IdIn(placeIds);

    // 조회 결과를 placeIds 순서대로 정렬
    Map<Long, Place> placeMap =
        places.stream().collect(Collectors.toMap(Place::getId, Function.identity()));
    List<Place> orderedPlaces = placeIds.stream().map(placeMap::get).toList();
``` 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
