### PR TITLE
Feat: 쏠맵 검색결과 없을시 주변 장소 프리뷰 조회 기능 구현 (#59)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -173,4 +173,19 @@ public class SolmapController {
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
+
+  @Operation(summary = "검색결과 없을시 주변 장소 조회 API", description = "검색결과 없을시 주변 장소 조회 API 입니다.")
+  @GetMapping("/places/nearby")
+  public ResponseEntity<SuccessResponse<PlaceSearchPreviewResponse>> getPlacesPreviewNearby(
+      @RequestParam Double userLat,
+      @RequestParam Double userLng,
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(required = false) Double cursorDist,
+      @RequestParam(required = false, defaultValue = "5") int limit) {
+
+    PlaceSearchPreviewResponse response =
+        solmapService.getPlacesPreviewNearby(userLat, userLng, cursorId, cursorDist, limit);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -200,7 +200,7 @@ public class SolmapService {
     }
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   public PlaceSearchPreviewResponse getPlacesPreview(
       Double swLat,
       Double swLng,
@@ -217,65 +217,21 @@ public class SolmapService {
     validViewport(swLat, swLng, neLat, neLng);
     validCategory(category);
 
-    NumberExpression<Double> distance = distance(userLat, userLng);
-
     // 좌표에 속한 장소 조회
     List<Place> places =
-        jpaQueryFactory
-            .selectFrom(p)
-            .distinct()
-            .leftJoin(p.placeCategories, pc)
-            .leftJoin(pc.category, c)
-            .leftJoin(p.placeHours, ph)
-            .where(
-                viewPortIn(swLat, swLng, neLat, neLng),
-                categoryIn(category),
-                cursorAfter(cursorId, cursorDist, distance))
-            .orderBy(distance.asc(), p.id.asc())
-            .limit(limit + 1) // 커서 페이징을 위해 limit+1개 조회 (limit개 + nextCursor용 1개)
-            .fetch();
+        getPlacesByViewPort(
+            swLat, swLng, neLat, neLng, userLat, userLng, category, cursorId, cursorDist, limit);
 
     // 다음 페이지 커서 값 세팅 (limit+1번째 데이터가 존재할 경우에만)
-    Long nextCursor = null;
-    Double nextCursorDist = null;
-    if (places.size() > limit) {
-      nextCursor = places.get(limit - 1).getId();
-      Place place = places.get(limit - 1);
-      nextCursorDist =
-          getNextCursorDistance(userLat, userLng, place.getLatitude(), place.getLongitude());
-    }
+    CursorInfo next = setNextCursor(places, userLat, userLng, limit);
 
-    List<PlacePreviewDetail> placePreviewDetails =
-        places.stream()
-            .limit(limit) // limit개만 결과로 반환
-            .map(
-                p -> {
-                  List<String> topTagsForPlace =
-                      placeRepository.getTopTagsForPlace(p.getId(), TAG_LIMIT);
-                  List<String> reviewThumbnails =
-                      placeRepository.getReviewThumbnails(p.getId(), PREVIEW_THUMBNAIL_LIMIT);
-                  OpenStatus openStatus = getOpenStatus(p);
-                  Integer isSoloRecommendedPercent =
-                      placeRepository.getRecommendationPercent(p.getId());
-
-                  return PlacePreviewDetail.builder()
-                      .id(p.getId())
-                      .name(p.getName())
-                      .detailedCategory(p.getTypes())
-                      .tags(topTagsForPlace)
-                      .isSoloRecommended(isSoloRecommendedPercent)
-                      .rating(p.getRating())
-                      .isOpen(openStatus.isOpen())
-                      .closingTime(openStatus.closingTime())
-                      .thumbnailUrls(reviewThumbnails)
-                      .build();
-                })
-            .toList();
+    // PreviewDetail DTO 매핑
+    List<PlacePreviewDetail> placePreviewDetails = mapToPreviewDetails(places, limit);
 
     return PlaceSearchPreviewResponse.builder()
         .places(placePreviewDetails)
-        .nextCursor(nextCursor)
-        .nextCursorDist(nextCursorDist)
+        .nextCursor(next.id())
+        .nextCursorDist(next.distance())
         .build();
   }
 
@@ -304,6 +260,34 @@ public class SolmapService {
         p.longitude, // {2}
         userLng // {3}
         );
+  }
+
+  private List<Place> getPlacesByViewPort(
+      Double swLat,
+      Double swLng,
+      Double neLat,
+      Double neLng,
+      Double userLat,
+      Double userLng,
+      String category,
+      Long cursorId,
+      Double cursorDist,
+      int limit) {
+    NumberExpression<Double> distance = distance(userLat, userLng);
+
+    return jpaQueryFactory
+        .selectFrom(p)
+        .distinct()
+        .leftJoin(p.placeCategories, pc)
+        .leftJoin(pc.category, c)
+        .leftJoin(p.placeHours, ph)
+        .where(
+            viewPortIn(swLat, swLng, neLat, neLng),
+            categoryIn(category),
+            cursorAfter(cursorId, cursorDist, distance))
+        .orderBy(distance.asc(), p.id.asc())
+        .limit(limit + 1) // 커서 페이징을 위해 limit+1개 조회 (limit개 + nextCursor용 1개)
+        .fetch();
   }
 
   // 커서(다음 페이지)용 거리 계산
@@ -582,7 +566,7 @@ public class SolmapService {
                   .detailedCategory(p.getTypes())
                   .tags(topTagsForPlace)
                   .isSoloRecommended(isSoloRecommendedPercent)
-                  .rating(p.getRating())
+                  .rating(truncateTo2Decimals(p.getRating()))
                   .isOpen(openStatus.isOpen())
                   .closingTime(openStatus.closingTime())
                   .thumbnailUrls(reviewThumbnails)

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
                         "/api/solmap/region/*/markers",
                         "/api/solmap/region/*/places",
                         "/api/solmap/place/search/*",
-                        "/api/sollect/popular")
+                        "/api/sollect/popular",
+                        "/api/solmap/places/nearby")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/sollect/*")
                     .permitAll()


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#59 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠맵 검색결과 없을시 주변 장소 프리뷰 조회 기능을 구현하였습니다.
- 지도 화면 내의 장소 프리뷰 조회 API를 기능마다 메서드 분리하는 리펙토링을 하였습니다.

- 사용자 현 위치에서 반경 km이내의 장소들을 조회할수 있게 하였습니다.
```java
  private static final int NEARBY_RADIUS_KM_LIMIT = 2;

// ...

  private BooleanExpression nearby(NumberExpression<Double> distance) {
    return distance.loe(NEARBY_RADIUS_KM_LIMIT);
  }
``` 

- 다음과 같이 각 기능을 메서드로 분리하였습니다.
```java
    // 좌표에 속한 장소 조회
    List<Place> places =
        getPlacesByViewPort(
            swLat, swLng, neLat, neLng, userLat, userLng, category, cursorId, cursorDist, limit);

    // 다음 페이지 커서 값 세팅 (limit+1번째 데이터가 존재할 경우에만)
    CursorInfo next = setNextCursor(places, userLat, userLng, limit);

    // PreviewDetail DTO 매핑
    List<PlacePreviewDetail> placePreviewDetails = mapToPreviewDetails(places, limit);
``` 


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 코드 리펙토링