### PR TITLE
Refactor: 쏠렉트 등록 에러 해결 (#63)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/sollect/entity/SollectContent.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/entity/SollectContent.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -39,6 +40,8 @@ public class SollectContent extends Timestamped {
   @Column(nullable = false)
   private ContentType type;
 
+  @Lob
+  @Column(columnDefinition = "TEXT")
   private String text;
 
   private String imageUrl;

--- a/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
@@ -481,6 +481,7 @@ public class SollectService {
   private SollectContent findImage(List<SollectContent> sollectContents, String filename) {
     for (SollectContent sollectContent : sollectContents) {
       if (sollectContent.getType().equals(ContentType.IMAGE)
+          && sollectContent.getImageUrl() == null
           && sollectContent.getFilename().equals(filename)) {
         return sollectContent;
       }


### PR DESCRIPTION
## #️⃣ Issue Number
#63 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
쏠렉트 본문 내용이 너무 길때를 대비해 `text`의 타입을 TEXT로,
쏠렉트의 이미지들의 이름이 같을때, 이를 해결할 수 있는 로직을 추가했습니다.
```
if (sollectContent.getType().equals(ContentType.IMAGE)
          && sollectContent.getImageUrl() == null
          && sollectContent.getFilename().equals(filename)) {
        return sollectContent;
```
다음과 같이 getImageUrl() == null 일때 (아직 이미지 업로드가 안된상태일때) sollectContent를 리턴하도록 했습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링

