### PR TITLE
Feat: 리뷰 조회 기능 구현(#62)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -188,4 +188,16 @@ public class SolmapController {
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
+
+  @Operation(summary = "리뷰 조회 API", description = "리뷰 조회 API 입니다.")
+  @GetMapping("/place/{id}/reviews")
+  public ResponseEntity<SuccessResponse<ReviewPageResponse>> getReviewDetails(
+      @PathVariable Long id,
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(required = false, defaultValue = "5") int limit) {
+
+    ReviewPageResponse response = solmapService.getReviewDetails(id, cursorId, limit);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/ReviewPageResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/ReviewPageResponse.java
@@ -1,0 +1,9 @@
+package com.ilta.solepli.domain.solmap.dto;
+
+import java.util.List;
+
+public record ReviewPageResponse(List<ReviewDetail> reviews, Long nextCursor) {
+  public static ReviewPageResponse of(List<ReviewDetail> reviews, Long nextCursor) {
+    return new ReviewPageResponse(reviews, nextCursor);
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
@@ -1,4 +1,4 @@
-package com.ilta.solepli.domain.place.repository;
+package com.ilta.solepli.domain.solmark.place.repository;
 
 import java.util.List;
 

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -56,7 +56,8 @@ public class SecurityConfig {
                         "/api/solmap/place/search/*",
                         "/api/sollect/popular",
                         "/api/sollect/related/*",
-                        "/api/solmap/places/nearby")
+                        "/api/solmap/places/nearby",
+                        "/api/solmap/place/*/reviews")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/sollect/*")
                     .permitAll()

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -75,7 +75,10 @@ public enum ErrorCode {
   CONTENT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 콘텐츠 이미지를 찾을 수 없습니다."),
 
   // 최근 검색어 관련 에러
-  RECENT_SEARCH_NOT_FOUND(HttpStatus.NOT_FOUND, "삭제하려는 최근 검색어가 존재하지 않습니다.");
+  RECENT_SEARCH_NOT_FOUND(HttpStatus.NOT_FOUND, "삭제하려는 최근 검색어가 존재하지 않습니다."),
+
+  // 리뷰 관련 에러
+  REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰 입니다.");
 
   private final HttpStatus httpStatus;
   private final String message;


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#62 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠맵의 리뷰 조회 기능을 구현 하였습니다.

- 다음과 같이 리뷰를 조회하는데 fetch join과 limit을 같이 사용해서 HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory 오류가 발생했습니다.

```java
jpaQueryFactory
        .selectFrom(r)
        .leftJoin(r.reviewImages)
        .fetchJoin()
        .join(r.user)
        .fetchJoin()
        .where(placeIdEq(placeId).and(reviewIdLT(cursorId)).and(r.deletedAt.isNull()))
        .orderBy(r.id.desc())
        .limit(limit + 1)
        .fetch();
``` 
- 컬렉션(fetchJoin)과 페이징(limit)이 동시에 적용될 때 발생하는 “in-memory pagination” 문제를 다음과 같이 해결했습니다.
- 먼저 필요한 리뷰 ID만 조회(limit 적용), 그 후에 해당 ID 목록을 기반으로 연관된 이미지와 사용자 정보를 fetch join하여 한 번에 로드하도록 변경했습니다. 
```java
    List<Long> ids =
        jpaQueryFactory
            .select(r.id)
            .from(r)
            .where(placeIdEq(placeId).and(reviewIdLT(cursorId)).and(r.deletedAt.isNull()))
            .orderBy(r.id.desc())
            .limit(limit + 1)
            .fetch();

    return jpaQueryFactory
        .selectFrom(r)
        .distinct()
        .leftJoin(r.reviewImages)
        .fetchJoin()
        .join(r.user)
        .fetchJoin()
        .where(r.id.in(ids))
        .orderBy(r.id.desc())
        .fetch();
``` 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
