### PR TITLE
Feat: 쏠마크-장소 관련 엔티티 추가 및 회원가입시 쏠마크 장소 리스트 추가#68

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
@@ -54,7 +54,7 @@ public class AuthService {
                 .build());
 
     SolmarkPlaceCollection solmarkPlaceCollection =
-        SolmarkPlaceCollection.builder().name("장소 리스트").iconId(1).user(savedUser).build();
+        SolmarkPlaceCollection.builder().name("저장 리스트").iconId(1).user(savedUser).build();
 
     solmarkPlaceCollectionRepository.save(solmarkPlaceCollection);
   }

--- a/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
@@ -12,6 +12,8 @@ import com.ilta.solepli.domain.auth.dto.response.LoginResponse;
 import com.ilta.solepli.domain.auth.entity.LoginType;
 import com.ilta.solepli.domain.auth.service.oauth.OAuthService;
 import com.ilta.solepli.domain.auth.service.oauth.OAuthServiceFactory;
+import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
+import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceCollectionRepository;
 import com.ilta.solepli.domain.user.entity.Role;
 import com.ilta.solepli.domain.user.entity.User;
 import com.ilta.solepli.domain.user.repository.UserRepository;
@@ -28,6 +30,7 @@ public class AuthService {
   private final OAuthServiceFactory oauthServiceFactory;
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
+  private final SolmarkPlaceCollectionRepository solmarkPlaceCollectionRepository;
 
   @Value("${DEFAULT_PROFILE_URL}")
   private String defaultImageUrl;
@@ -40,14 +43,20 @@ public class AuthService {
       throw new CustomException(ErrorCode.USER_EXISTS);
     }
 
-    userRepository.save(
-        User.builder()
-            .role(Role.ADMIN)
-            .loginId(loginId)
-            .password(passwordEncoder.encode(request.password()))
-            .profileImageUrl(defaultImageUrl)
-            .nickname(userService.generateAdminNickname())
-            .build());
+    User savedUser =
+        userRepository.save(
+            User.builder()
+                .role(Role.ADMIN)
+                .loginId(loginId)
+                .password(passwordEncoder.encode(request.password()))
+                .profileImageUrl(defaultImageUrl)
+                .nickname(userService.generateAdminNickname())
+                .build());
+
+    SolmarkPlaceCollection solmarkPlaceCollection =
+        SolmarkPlaceCollection.builder().name("장소 리스트").iconId(1).user(savedUser).build();
+
+    solmarkPlaceCollectionRepository.save(solmarkPlaceCollection);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -403,7 +403,7 @@ public class SolmapService {
 
     // 쏠마크 장소 조회
     List<SolmarkPlace> solmarkPlaces =
-        solmarkPlaceRepository.findBySolmarkPlaceList_UserAndPlace_idIn(user, placeIds);
+        solmarkPlaceRepository.findBySolmarkPlaceCollection_UserAndPlace_idIn(user, placeIds);
 
     // 쏠마크 장소 ID Set 반환
     return solmarkPlaces.stream().map(sp -> sp.getPlace().getId()).collect(Collectors.toSet());

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -403,7 +403,7 @@ public class SolmapService {
 
     // 쏠마크 장소 조회
     List<SolmarkPlace> solmarkPlaces =
-        solmarkPlaceRepository.findAllByUserAndPlace_IdIn(user, placeIds);
+        solmarkPlaceRepository.findBySolmarkPlaceList_UserAndPlace_idIn(user, placeIds);
 
     // 쏠마크 장소 ID Set 반환
     return solmarkPlaces.stream().map(sp -> sp.getPlace().getId()).collect(Collectors.toSet());

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlace.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlace.java
@@ -20,9 +20,9 @@ public class SolmarkPlace {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "solmark_place_list_id")
+  @JoinColumn(name = "solmark_place_collection_id")
   @OnDelete(action = OnDeleteAction.CASCADE)
-  private SolmarkPlaceList solmarkPlaceList;
+  private SolmarkPlaceCollection solmarkPlaceCollection;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "place_id")

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceCollection.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceCollection.java
@@ -12,8 +12,8 @@ import com.ilta.solepli.domain.user.entity.User;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "solmark_place_list")
-public class SolmarkPlaceList {
+@Table(name = "solmark_place_collections")
+public class SolmarkPlaceCollection {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceList.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceList.java
@@ -5,27 +5,28 @@ import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import com.ilta.solepli.domain.place.entity.Place;
+import com.ilta.solepli.domain.user.entity.User;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "solmark_places")
-public class SolmarkPlace {
+@Table(name = "solmark_place_list")
+public class SolmarkPlaceList {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "solmark_place_list_id")
+  @JoinColumn(name = "user_id")
   @OnDelete(action = OnDeleteAction.CASCADE)
-  private SolmarkPlaceList solmarkPlaceList;
+  private User user;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "place_id")
-  @OnDelete(action = OnDeleteAction.CASCADE)
-  private Place place;
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private int iconId;
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
@@ -1,0 +1,8 @@
+package com.ilta.solepli.domain.solmark.place.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
+
+public interface SolmarkPlaceCollectionRepository
+    extends JpaRepository<SolmarkPlaceCollection, Long> {}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
@@ -9,6 +9,6 @@ import com.ilta.solepli.domain.user.entity.User;
 
 public interface SolmarkPlaceRepository extends JpaRepository<SolmarkPlace, Long> {
 
-  List<SolmarkPlace> findBySolmarkPlaceList_UserAndPlace_idIn(
+  List<SolmarkPlace> findBySolmarkPlaceCollection_UserAndPlace_idIn(
       User solmarkPlaceListUser, List<Long> placeIds);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
@@ -3,13 +3,12 @@ package com.ilta.solepli.domain.solmark.place.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlace;
 import com.ilta.solepli.domain.user.entity.User;
 
-@Repository
 public interface SolmarkPlaceRepository extends JpaRepository<SolmarkPlace, Long> {
 
-  List<SolmarkPlace> findAllByUserAndPlace_IdIn(User user, List<Long> placeIds);
+  List<SolmarkPlace> findBySolmarkPlaceList_UserAndPlace_idIn(
+      User solmarkPlaceListUser, List<Long> placeIds);
 }

--- a/src/main/java/com/ilta/solepli/domain/user/service/UserService.java
+++ b/src/main/java/com/ilta/solepli/domain/user/service/UserService.java
@@ -9,6 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
+import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceCollectionRepository;
 import com.ilta.solepli.domain.user.entity.Role;
 import com.ilta.solepli.domain.user.entity.User;
 import com.ilta.solepli.domain.user.repository.UserRepository;
@@ -18,6 +20,7 @@ import com.ilta.solepli.domain.user.repository.UserRepository;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final SolmarkPlaceCollectionRepository solmarkPlaceCollectionRepository;
 
   private final String[] ADJECTIVES = {
     "귀여운", "용감한", "날쌘", "온순한", "영리한", "수줍은", "호기심많은", "느긋한", "활발한", "우아한", "엉뚱한", "애교많은", "부지런한"
@@ -72,14 +75,23 @@ public class UserService {
     return userRepository
         .findByLoginId(loginId)
         .orElseGet(
-            () ->
-                userRepository.save(
-                    User.builder()
-                        .role(Role.USER)
-                        .loginId(loginId)
-                        .profileImageUrl(defaultImageUrl)
-                        .nickname(checkedNickname)
-                        .build()));
+            () -> {
+              User savedUser =
+                  userRepository.save(
+                      User.builder()
+                          .role(Role.USER)
+                          .loginId(loginId)
+                          .profileImageUrl(defaultImageUrl)
+                          .nickname(checkedNickname)
+                          .build());
+
+              SolmarkPlaceCollection solmarkPlaceCollection =
+                  SolmarkPlaceCollection.builder().name("저장 리스트").iconId(1).user(savedUser).build();
+
+              solmarkPlaceCollectionRepository.save(solmarkPlaceCollection);
+
+              return savedUser;
+            });
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#68 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠마크-장소 관련 엔티티를 추가하였습니다.
- 사용자는 초기에 저장 리스트를 가지고 있어야해서 회원 가입시 저장 리스트 엔티티를 생성하도록 하였습니다.
![image](https://github.com/user-attachments/assets/fed4d60f-cf89-4dc4-802e-777a32443cb9)
```java
    User savedUser =
        userRepository.save(
            User.builder()
                .role(Role.ADMIN)
                .loginId(loginId)
                .password(passwordEncoder.encode(request.password()))
                .profileImageUrl(defaultImageUrl)
                .nickname(userService.generateAdminNickname())
                .build());

    SolmarkPlaceCollection solmarkPlaceCollection =
        SolmarkPlaceCollection.builder().name("저장 리스트").iconId(1).user(savedUser).build();

    solmarkPlaceCollectionRepository.save(solmarkPlaceCollection);
``` 
- 사용자의 쏠마크 장소를 조회하는 메서드를 다음과 같이 사용하였습니다.
```java
    // 쏠마크 장소 조회
    List<SolmarkPlace> solmarkPlaces =
        solmarkPlaceRepository.findBySolmarkPlaceCollection_UserAndPlace_idIn(user, placeIds);
``` 


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
