### PR TITLE
Feat: 쏠마크 저장 리스트에 장소 추가 기능 구현 (#79)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import com.ilta.solepli.domain.solmark.place.dto.reqeust.AddSolmarkPlaceRequest;
 import com.ilta.solepli.domain.solmark.place.dto.reqeust.CreateCollectionRequest;
 import com.ilta.solepli.domain.solmark.place.service.SolmarkPlaceService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
@@ -33,5 +34,17 @@ public class SolmarkPlaceController {
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(SuccessResponse.successWithNoData("쏠마크 저장 리스트 추가 성공"));
+  }
+
+  @Operation(summary = "쏠마크 장소 추가 API", description = "쏠마크 장소 저장 리스트 추가 API 입니다.")
+  @PostMapping("")
+  public ResponseEntity<SuccessResponse<Void>> addSolmarkPlace(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @RequestBody AddSolmarkPlaceRequest addSolmarkPlaceRequest) {
+
+    solmarkPlaceService.addSolmarkPlace(customUserDetails, addSolmarkPlaceRequest);
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(SuccessResponse.successWithNoData("쏠마크 장소 추가 성공"));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/dto/reqeust/AddSolmarkPlaceRequest.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/dto/reqeust/AddSolmarkPlaceRequest.java
@@ -1,0 +1,5 @@
+package com.ilta.solepli.domain.solmark.place.dto.reqeust;
+
+import java.util.List;
+
+public record AddSolmarkPlaceRequest(List<Long> collectionIds, Long placeId) {}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceCollection.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceCollection.java
@@ -1,5 +1,8 @@
 package com.ilta.solepli.domain.solmark.place.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
@@ -29,4 +32,7 @@ public class SolmarkPlaceCollection {
 
   @Column(nullable = false)
   private int iconId;
+
+  @OneToMany(mappedBy = "solmarkPlaceCollection", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<SolmarkPlace> solmarkPlaces = new ArrayList<>();
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
@@ -1,5 +1,7 @@
 package com.ilta.solepli.domain.solmark.place.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
@@ -9,4 +11,6 @@ public interface SolmarkPlaceCollectionRepository
     extends JpaRepository<SolmarkPlaceCollection, Long> {
 
   Integer countByUser(User user);
+
+  List<SolmarkPlaceCollection> findByUserAndId_In(User user, List<Long> collectionIds);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
@@ -3,6 +3,7 @@ package com.ilta.solepli.domain.solmark.place.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
 import com.ilta.solepli.domain.user.entity.User;
@@ -12,5 +13,12 @@ public interface SolmarkPlaceCollectionRepository
 
   Integer countByUser(User user);
 
+  @Query(
+      """
+    SELECT DISTINCT spc
+    FROM SolmarkPlaceCollection spc
+    JOIN FETCH spc.solmarkPlaces sp
+    WHERE spc.user = :user AND spc.id IN :collectionIds
+""")
   List<SolmarkPlaceCollection> findByUserAndId_In(User user, List<Long> collectionIds);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
@@ -4,11 +4,16 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlace;
+import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
 import com.ilta.solepli.domain.user.entity.User;
 
 public interface SolmarkPlaceRepository extends JpaRepository<SolmarkPlace, Long> {
 
   List<SolmarkPlace> findBySolmarkPlaceCollection_UserAndPlace_idIn(
       User solmarkPlaceListUser, List<Long> placeIds);
+
+  Boolean existsBySolmarkPlaceCollectionInAndPlace(
+      List<SolmarkPlaceCollection> solmarkPlaceCollection, Place place);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.place.repository.PlaceRepository;
@@ -20,6 +21,7 @@ import com.ilta.solepli.domain.user.util.CustomUserDetails;
 import com.ilta.solepli.global.exception.CustomException;
 import com.ilta.solepli.global.exception.ErrorCode;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SolmarkPlaceService {
@@ -27,6 +29,9 @@ public class SolmarkPlaceService {
   private final SolmarkPlaceCollectionRepository solmarkPlaceCollectionRepository;
   private final PlaceRepository placeRepository;
   private final SolmarkPlaceRepository solmarkPlaceRepository;
+
+  private static final int MAX_PLACES_PER_COLLECTION = 100;
+  private static final int MAX_COLLECTIONS_PER_USER = 50;
 
   @Transactional
   public void createCollection(
@@ -38,7 +43,7 @@ public class SolmarkPlaceService {
     Integer count = solmarkPlaceCollectionRepository.countByUser(user);
 
     // 최대 개수(50) 검증
-    if (count >= 50) {
+    if (count >= MAX_COLLECTIONS_PER_USER) {
       throw new CustomException(ErrorCode.COLLECTION_LIMIT_EXCEEDED);
     }
 
@@ -65,20 +70,45 @@ public class SolmarkPlaceService {
             .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_EXISTS));
 
     // 요청 데이터 collectionIds를 기반으로 사용자 쏠마크 저장 리스트 조회
-    List<SolmarkPlaceCollection> collections =
-        solmarkPlaceCollectionRepository.findByUserAndId_In(user, collectionIds);
+    List<SolmarkPlaceCollection> collections = validateAndGetCollections(user, collectionIds);
 
     // 추가할 저장 리스트에 이미 저장된 장소인지 검증
-    if (solmarkPlaceRepository.existsBySolmarkPlaceCollectionInAndPlace(collections, place)) {
-      throw new CustomException(ErrorCode.DUPLICATED_MARK_PLACE);
-    }
+    validateCollectionPlaceDuplicate(collections, place);
 
     // 조회한 쏠마크 저장 리스트에 추가할 SolmarkPlace 객체 리스트
     List<SolmarkPlace> solmarkPlaces =
         collections.stream()
-            .map(c -> SolmarkPlace.builder().solmarkPlaceCollection(c).place(place).build())
+            .map(
+                c -> {
+                  // 각 장소 리스트별 최대 장소 저장 개수 검증
+                  validateCollectionPlaceLimit(c);
+
+                  return SolmarkPlace.builder().solmarkPlaceCollection(c).place(place).build();
+                })
             .toList();
 
     solmarkPlaceRepository.saveAll(solmarkPlaces);
+  }
+
+  private List<SolmarkPlaceCollection> validateAndGetCollections(User user, List<Long> ids) {
+    List<SolmarkPlaceCollection> cols =
+        solmarkPlaceCollectionRepository.findByUserAndId_In(user, ids);
+    if (cols.size() != ids.size()) {
+      throw new CustomException(ErrorCode.COLLECTION_NOT_FOUND);
+    }
+    return cols;
+  }
+
+  private void validateCollectionPlaceLimit(SolmarkPlaceCollection c) {
+    if (c.getSolmarkPlaces().size() >= MAX_PLACES_PER_COLLECTION) {
+      throw new CustomException(ErrorCode.EXCEEDED_MARK_PLACE_LIMIT);
+    }
+  }
+
+  private void validateCollectionPlaceDuplicate(
+      List<SolmarkPlaceCollection> collections, Place place) {
+    if (solmarkPlaceRepository.existsBySolmarkPlaceCollectionInAndPlace(collections, place)) {
+      throw new CustomException(ErrorCode.DUPLICATED_MARK_PLACE);
+    }
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -68,6 +68,11 @@ public class SolmarkPlaceService {
     List<SolmarkPlaceCollection> collections =
         solmarkPlaceCollectionRepository.findByUserAndId_In(user, collectionIds);
 
+    // 추가할 저장 리스트에 이미 저장된 장소인지 검증
+    if (solmarkPlaceRepository.existsBySolmarkPlaceCollectionInAndPlace(collections, place)) {
+      throw new CustomException(ErrorCode.DUPLICATED_MARK_PLACE);
+    }
+
     // 조회한 쏠마크 저장 리스트에 추가할 SolmarkPlace 객체 리스트
     List<SolmarkPlace> solmarkPlaces =
         collections.stream()

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -1,13 +1,20 @@
 package com.ilta.solepli.domain.solmark.place.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.ilta.solepli.domain.place.entity.Place;
+import com.ilta.solepli.domain.place.repository.PlaceRepository;
+import com.ilta.solepli.domain.solmark.place.dto.reqeust.AddSolmarkPlaceRequest;
 import com.ilta.solepli.domain.solmark.place.dto.reqeust.CreateCollectionRequest;
+import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlace;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
 import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceCollectionRepository;
+import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceRepository;
 import com.ilta.solepli.domain.user.entity.User;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
 import com.ilta.solepli.global.exception.CustomException;
@@ -18,6 +25,8 @@ import com.ilta.solepli.global.exception.ErrorCode;
 public class SolmarkPlaceService {
 
   private final SolmarkPlaceCollectionRepository solmarkPlaceCollectionRepository;
+  private final PlaceRepository placeRepository;
+  private final SolmarkPlaceRepository solmarkPlaceRepository;
 
   @Transactional
   public void createCollection(
@@ -42,5 +51,29 @@ public class SolmarkPlaceService {
             .build();
 
     solmarkPlaceCollectionRepository.save(placeCollection);
+  }
+
+  @Transactional
+  public void addSolmarkPlace(
+      CustomUserDetails customUserDetails, AddSolmarkPlaceRequest addSolmarkPlaceRequest) {
+    User user = customUserDetails.user();
+    List<Long> collectionIds = addSolmarkPlaceRequest.collectionIds();
+    // 추가할 장소 조회
+    Place place =
+        placeRepository
+            .findById(addSolmarkPlaceRequest.placeId())
+            .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_EXISTS));
+
+    // 요청 데이터 collectionIds를 기반으로 사용자 쏠마크 저장 리스트 조회
+    List<SolmarkPlaceCollection> collections =
+        solmarkPlaceCollectionRepository.findByUserAndId_In(user, collectionIds);
+
+    // 조회한 쏠마크 저장 리스트에 추가할 SolmarkPlace 객체 리스트
+    List<SolmarkPlace> solmarkPlaces =
+        collections.stream()
+            .map(c -> SolmarkPlace.builder().solmarkPlaceCollection(c).place(place).build())
+            .toList();
+
+    solmarkPlaceRepository.saveAll(solmarkPlaces);
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -93,6 +93,7 @@ public class SolmarkPlaceService {
   private List<SolmarkPlaceCollection> validateAndGetCollections(User user, List<Long> ids) {
     List<SolmarkPlaceCollection> cols =
         solmarkPlaceCollectionRepository.findByUserAndId_In(user, ids);
+    // 저장 리스트 ID 검증
     if (cols.size() != ids.size()) {
       throw new CustomException(ErrorCode.COLLECTION_NOT_FOUND);
     }

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
 
   // 장소 관련 에러
   PLACE_NOT_EXISTS(HttpStatus.NOT_FOUND, "존재하지 않는 장소입니다."),
+  DUPLICATED_MARK_PLACE(HttpStatus.CONFLICT, "이미 저장된 장소입니다"),
 
   // S3 관련 에러
   EMPTY_IMAGE(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
   // 장소 관련 에러
   PLACE_NOT_EXISTS(HttpStatus.NOT_FOUND, "존재하지 않는 장소입니다."),
   DUPLICATED_MARK_PLACE(HttpStatus.CONFLICT, "쏠마크 저장 리스트에 추가되어있는 장소입니다"),
+  EXCEEDED_MARK_PLACE_LIMIT(HttpStatus.BAD_REQUEST, "저장 리스트에 추가할 수 있는 장소 수가 최대 100개를 초과했습니다."),
 
   // S3 관련 에러
   EMPTY_IMAGE(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),
@@ -82,7 +83,8 @@ public enum ErrorCode {
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰 입니다."),
 
   // 쏠마크 - 장소 관련 에러
-  COLLECTION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "저장 리스트는 최대 50개까지만 생성할 수 있습니다.");
+  COLLECTION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "저장 리스트는 최대 50개까지만 생성할 수 있습니다."),
+  COLLECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 저장 리스트 입니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
 
   // 장소 관련 에러
   PLACE_NOT_EXISTS(HttpStatus.NOT_FOUND, "존재하지 않는 장소입니다."),
-  DUPLICATED_MARK_PLACE(HttpStatus.CONFLICT, "이미 저장된 장소입니다"),
+  DUPLICATED_MARK_PLACE(HttpStatus.CONFLICT, "쏠마크 저장 리스트에 추가되어있는 장소입니다"),
 
   // S3 관련 에러
   EMPTY_IMAGE(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),


### PR DESCRIPTION

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#79 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠마크 - 장소 저장 리스트에 장소 추가 기능을 구현하였습니다.
- 요청 DTO에서 받은 저장 리스트 ID가 올바른 ID인지 validateAndGetCollections 메서드로 검증하도록 하였습니다.
- 각 저장 리스트에 최대 50개의 장소 추가가 가능해서 최대 50개 까지만 추가할수 있도록 validateCollectionPlaceLimit 메서드로 검증하였습니다.
- 저장 리스트에 이미 저장되어 있는 장소를 또 추가하지 못하도록 validateCollectionPlaceDuplicate 메서드로 검증하였습니다.

```java
  private List<SolmarkPlaceCollection> validateAndGetCollections(User user, List<Long> ids) {
    List<SolmarkPlaceCollection> cols =
        solmarkPlaceCollectionRepository.findByUserAndId_In(user, ids);
    // 저장 리스트 ID 검증
    if (cols.size() != ids.size()) {
      throw new CustomException(ErrorCode.COLLECTION_NOT_FOUND);
    }
    return cols;
  }

  private void validateCollectionPlaceLimit(SolmarkPlaceCollection c) {
    if (c.getSolmarkPlaces().size() >= MAX_PLACES_PER_COLLECTION) {
      throw new CustomException(ErrorCode.EXCEEDED_MARK_PLACE_LIMIT);
    }
  }

  private void validateCollectionPlaceDuplicate(
      List<SolmarkPlaceCollection> collections, Place place) {
    if (solmarkPlaceRepository.existsBySolmarkPlaceCollectionInAndPlace(collections, place)) {
      throw new CustomException(ErrorCode.DUPLICATED_MARK_PLACE);
    }
  }
``` 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
