### PR TITLE
Feat: 쏠마크 - 장소 저장 리스트 조회 기능 구현 (#81)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/service/SollectService.java
@@ -552,7 +552,7 @@ public class SollectService {
 
     // 쏠마크 장소 조회
     List<SolmarkPlace> solmarkPlaces =
-        solmarkPlaceRepository.findBySolmarkPlaceCollection_UserAndPlace_idIn(user, placeIds);
+        solmarkPlaceRepository.findAllNonDeletedByUserAndPlaceIds(user, placeIds);
 
     // 쏠마크 장소 ID Set 반환
     return solmarkPlaces.stream().map(sp -> sp.getPlace().getId()).collect(Collectors.toSet());

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -403,7 +403,7 @@ public class SolmapService {
 
     // 쏠마크 장소 조회
     List<SolmarkPlace> solmarkPlaces =
-        solmarkPlaceRepository.findBySolmarkPlaceCollection_UserAndPlace_idIn(user, placeIds);
+        solmarkPlaceRepository.findAllNonDeletedByUserAndPlaceIds(user, placeIds);
 
     // 쏠마크 장소 ID Set 반환
     return solmarkPlaces.stream().map(sp -> sp.getPlace().getId()).collect(Collectors.toSet());

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
@@ -1,5 +1,7 @@
 package com.ilta.solepli.domain.solmark.place.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.ilta.solepli.domain.solmark.place.dto.reqeust.AddSolmarkPlaceRequest;
 import com.ilta.solepli.domain.solmark.place.dto.reqeust.CreateCollectionRequest;
+import com.ilta.solepli.domain.solmark.place.dto.response.CollectionResponse;
 import com.ilta.solepli.domain.solmark.place.service.SolmarkPlaceService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
 import com.ilta.solepli.global.response.SuccessResponse;
@@ -46,5 +49,15 @@ public class SolmarkPlaceController {
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(SuccessResponse.successWithNoData("쏠마크 장소 추가 성공"));
+  }
+
+  @Operation(summary = "쏠마크 장소 저장 리스트 조회 API", description = "쏠마크 장소 저장 리스트 조회 API 입니다.")
+  @GetMapping("collections")
+  public ResponseEntity<SuccessResponse<List<CollectionResponse>>> getCollections(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+    List<CollectionResponse> response = solmarkPlaceService.getCollections(customUserDetails);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/dto/response/CollectionResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/dto/response/CollectionResponse.java
@@ -1,0 +1,7 @@
+package com.ilta.solepli.domain.solmark.place.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CollectionResponse(
+    Long collectionId, int iconId, String collectionName, int placeCount) {}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlace.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlace.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import com.ilta.solepli.domain.place.entity.Place;
+import com.ilta.solepli.global.entity.Timestamped;
 
 @Entity
 @Getter
@@ -13,7 +14,7 @@ import com.ilta.solepli.domain.place.entity.Place;
 @AllArgsConstructor
 @Builder
 @Table(name = "solmark_places")
-public class SolmarkPlace {
+public class SolmarkPlace extends Timestamped {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceCollection.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceCollection.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import com.ilta.solepli.domain.user.entity.User;
+import com.ilta.solepli.global.entity.Timestamped;
 
 @Entity
 @Getter
@@ -16,7 +17,7 @@ import com.ilta.solepli.domain.user.entity.User;
 @AllArgsConstructor
 @Builder
 @Table(name = "solmark_place_collections")
-public class SolmarkPlaceCollection {
+public class SolmarkPlaceCollection extends Timestamped {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceCollection.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/entity/SolmarkPlaceCollection.java
@@ -34,5 +34,6 @@ public class SolmarkPlaceCollection {
   private int iconId;
 
   @OneToMany(mappedBy = "solmarkPlaceCollection", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
   private List<SolmarkPlace> solmarkPlaces = new ArrayList<>();
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
@@ -18,7 +18,7 @@ public interface SolmarkPlaceCollectionRepository
     SELECT DISTINCT spc
     FROM SolmarkPlaceCollection spc
     JOIN FETCH spc.solmarkPlaces sp
-    WHERE spc.user = :user AND spc.id IN :collectionIds
+    WHERE spc.user = :user AND spc.id IN :collectionIds AND spc.deletedAt IS NULL
 """)
   List<SolmarkPlaceCollection> findByUserAndId_In(User user, List<Long> collectionIds);
 
@@ -27,7 +27,7 @@ public interface SolmarkPlaceCollectionRepository
       SELECT spc
       FROM SolmarkPlaceCollection spc
       LEFT JOIN FETCH spc.solmarkPlaces sp
-      WHERE spc.user = :user
+      WHERE spc.user = :user AND spc.deletedAt IS NULL
    """)
   List<SolmarkPlaceCollection> findByUser(User user);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
@@ -21,4 +21,13 @@ public interface SolmarkPlaceCollectionRepository
     WHERE spc.user = :user AND spc.id IN :collectionIds
 """)
   List<SolmarkPlaceCollection> findByUserAndId_In(User user, List<Long> collectionIds);
+
+  @Query(
+      """
+      SELECT spc
+      FROM SolmarkPlaceCollection spc
+      LEFT JOIN FETCH spc.solmarkPlaces sp
+      WHERE spc.user = :user
+   """)
+  List<SolmarkPlaceCollection> findByUser(User user);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
@@ -3,6 +3,7 @@ package com.ilta.solepli.domain.solmark.place.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlace;
@@ -11,8 +12,17 @@ import com.ilta.solepli.domain.user.entity.User;
 
 public interface SolmarkPlaceRepository extends JpaRepository<SolmarkPlace, Long> {
 
-  List<SolmarkPlace> findBySolmarkPlaceCollection_UserAndPlace_idIn(
-      User solmarkPlaceListUser, List<Long> placeIds);
+  @Query(
+      """
+    SELECT sp
+    FROM SolmarkPlace sp
+    JOIN sp.solmarkPlaceCollection spc
+    WHERE spc.user = :user
+    AND sp.place.id IN :placeIds
+    AND sp.deletedAt IS NULL
+    AND spc.deletedAt IS NULL
+""")
+  List<SolmarkPlace> findAllNonDeletedByUserAndPlaceIds(User user, List<Long> placeIds);
 
   Boolean existsBySolmarkPlaceCollectionInAndPlace(
       List<SolmarkPlaceCollection> solmarkPlaceCollection, Place place);

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -12,6 +12,7 @@ import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.place.repository.PlaceRepository;
 import com.ilta.solepli.domain.solmark.place.dto.reqeust.AddSolmarkPlaceRequest;
 import com.ilta.solepli.domain.solmark.place.dto.reqeust.CreateCollectionRequest;
+import com.ilta.solepli.domain.solmark.place.dto.response.CollectionResponse;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlace;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
 import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceCollectionRepository;
@@ -111,5 +112,30 @@ public class SolmarkPlaceService {
     if (solmarkPlaceRepository.existsBySolmarkPlaceCollectionInAndPlace(collections, place)) {
       throw new CustomException(ErrorCode.DUPLICATED_MARK_PLACE);
     }
+  }
+
+  @Transactional(readOnly = true)
+  public List<CollectionResponse> getCollections(CustomUserDetails customUserDetails) {
+    User user = customUserDetails.user();
+
+    // 사용자 쏠마크 -장소 저장 리스트 조회
+    List<SolmarkPlaceCollection> solmarkPlaceCollections =
+        solmarkPlaceCollectionRepository.findByUser(user);
+
+    return solmarkPlaceCollections.stream()
+        // CollectionResponse DTO 매핑
+        .map(this::mapToCollectionResponse)
+        .toList();
+  }
+
+  private CollectionResponse mapToCollectionResponse(SolmarkPlaceCollection spc) {
+    int placeCount = spc.getSolmarkPlaces().size();
+
+    return CollectionResponse.builder()
+        .collectionId(spc.getId())
+        .iconId(spc.getIconId())
+        .collectionName(spc.getName())
+        .placeCount(placeCount)
+        .build();
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solroute/service/SolrouteService.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/service/SolrouteService.java
@@ -147,7 +147,7 @@ public class SolrouteService {
 
     // 쏠마크 장소 조회
     List<SolmarkPlace> solmarkPlaces =
-        solmarkPlaceRepository.findBySolmarkPlaceCollection_UserAndPlace_idIn(user, placeIds);
+        solmarkPlaceRepository.findAllNonDeletedByUserAndPlaceIds(user, placeIds);
 
     // 쏠마크 장소 ID Set 반환
     return solmarkPlaces.stream().map(sp -> sp.getPlace().getId()).collect(Collectors.toSet());


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#81 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠마크 - 장소 저장 리스트 조회 기능을 구현하였습니다.
- 다음과 같이 쏠마크 저장 리스트의 추가된 장소가 없어도 조회될수 있게 LEFT JOIN을 추가하였습니다.
```java
  @Query(
      """
      SELECT spc
      FROM SolmarkPlaceCollection spc
      LEFT JOIN FETCH spc.solmarkPlaces sp
      WHERE spc.user = :user
   """)
  List<SolmarkPlaceCollection> findByUser(User user);
``` 

- 사용자가 쏠마크한 장소(SolmarkPlace)를 조회하는 메서드를 사용자가 삭제하지 않은 쏠마크 저장 리스트와 쏠마크 장소를 조회하도록 수정하였습니다.
```java
  @Query(
      """
    SELECT sp
    FROM SolmarkPlace sp
    JOIN sp.solmarkPlaceCollection spc
    WHERE spc.user = :user
    AND sp.place.id IN :placeIds
    AND sp.deletedAt IS NULL
    AND spc.deletedAt IS NULL
""")
  List<SolmarkPlace> findAllNonDeletedByUserAndPlaceIds(User user, List<Long> placeIds);
``` 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
