### PR TITLE
Feat: 쏠마크 저장 리스트 조회 기능 구현 (#84)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import com.ilta.solepli.domain.solmark.place.dto.reqeust.AddSolmarkPlaceRequest;
 import com.ilta.solepli.domain.solmark.place.dto.reqeust.CreateCollectionRequest;
 import com.ilta.solepli.domain.solmark.place.dto.response.CollectionResponse;
+import com.ilta.solepli.domain.solmark.place.dto.response.SolmarkPlacesResponse;
 import com.ilta.solepli.domain.solmark.place.service.SolmarkPlaceService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
 import com.ilta.solepli.global.response.SuccessResponse;
@@ -57,6 +58,18 @@ public class SolmarkPlaceController {
       @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
     List<CollectionResponse> response = solmarkPlaceService.getCollections(customUserDetails);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+  }
+
+  @Operation(summary = "쏠마크 장소 리스트 조회 API", description = "쏠마크 장소 리스트 조회 API 입니다.")
+  @GetMapping("/collections/{collectionId}/places")
+  public ResponseEntity<SuccessResponse<SolmarkPlacesResponse>> getSolmarkPlaces(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable Long collectionId) {
+
+    SolmarkPlacesResponse response =
+        solmarkPlaceService.getSolmarkPlaces(customUserDetails, collectionId);
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/dto/response/SolmarkPlaceDto.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/dto/response/SolmarkPlaceDto.java
@@ -1,0 +1,14 @@
+package com.ilta.solepli.domain.solmark.place.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record SolmarkPlaceDto(
+    Long PlaceId,
+    String name,
+    String detailedCategory,
+    Integer recommendationPercent,
+    List<String> tags,
+    Double rating) {}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/dto/response/SolmarkPlacesResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/dto/response/SolmarkPlacesResponse.java
@@ -1,0 +1,9 @@
+package com.ilta.solepli.domain.solmark.place.dto.response;
+
+import java.util.List;
+
+public record SolmarkPlacesResponse(List<SolmarkPlaceDto> places, int placeCount) {
+  public static SolmarkPlacesResponse of(List<SolmarkPlaceDto> places, int placeCount) {
+    return new SolmarkPlacesResponse(places, placeCount);
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
@@ -26,4 +26,17 @@ public interface SolmarkPlaceRepository extends JpaRepository<SolmarkPlace, Long
 
   Boolean existsBySolmarkPlaceCollectionInAndPlace(
       List<SolmarkPlaceCollection> solmarkPlaceCollection, Place place);
+
+  @Query(
+      """
+    SELECT sp
+    FROM SolmarkPlace sp
+    JOIN sp.solmarkPlaceCollection spc
+    JOIN FETCH sp.place p
+    WHERE spc.deletedAt IS NULL
+    AND sp.deletedAt IS NULL
+    AND spc.user = :user
+    AND spc.id = :collectionId
+""")
+  List<SolmarkPlace> findByUserAndCollectionId(User user, Long collectionId);
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#84 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠마크 저장 리스트 조회 기능을 구현하였습니다.
- 응답으로 전달받은 collectionId(저장 리스트 ID)로 사용자의 특정 저장 리스트의 쏠마크 장소 리스트를 findByUserAndCollectionId 메서드로 조회하도록 하였습니다.
```java
  @Query(
      """
    SELECT sp
    FROM SolmarkPlace sp
    JOIN sp.solmarkPlaceCollection spc
    JOIN FETCH sp.place p
    WHERE spc.deletedAt IS NULL
    AND sp.deletedAt IS NULL
    AND spc.user = :user
    AND spc.id = :collectionId
""")
  List<SolmarkPlace> findByUserAndCollectionId(User user, Long collectionId);
``` 


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
