### PR TITLE
Feat: 추천 솔렉트 조회 기능 구현 (#83)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/sollect/controller/SollectController.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/controller/SollectController.java
@@ -32,6 +32,7 @@ import com.ilta.solepli.domain.sollect.dto.response.SollectDetailResponse;
 import com.ilta.solepli.domain.sollect.dto.response.SollectPlaceAddPreviewResponse;
 import com.ilta.solepli.domain.sollect.dto.response.SollectSearchResponse;
 import com.ilta.solepli.domain.sollect.dto.response.SollectSearchResponse.PopularSollectContent;
+import com.ilta.solepli.domain.sollect.dto.response.SollectSearchResponse.SollectSearchContent;
 import com.ilta.solepli.domain.sollect.service.SollectService;
 import com.ilta.solepli.domain.user.entity.User;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
@@ -195,5 +196,21 @@ public class SollectController {
         sollectService.getPlaceRelatedSollect(user, placeId, cursorId, size);
 
     return ResponseEntity.ok(SuccessResponse.successWithData(relatedSollects));
+  }
+
+  @Operation(summary = "추천 쏠렉트 조회 API", description = "키워드 + 카테고리를 and 조건으로 만족하는 쏠렉트를 조회 API 입니다.")
+  @GetMapping("/recommend")
+  public ResponseEntity<SuccessResponse<List<SollectSearchResponse.SollectSearchContent>>>
+      getRecommendSollects(
+          @AuthenticationPrincipal CustomUserDetails customUserDetails,
+          @RequestParam(required = false) String keyword,
+          @RequestParam(required = true) String categoryName) {
+
+    User user = SecurityUtil.getUser(customUserDetails);
+
+    List<SollectSearchContent> sollectSearchContents =
+        sollectService.recommendSollect(keyword, categoryName, user);
+
+    return ResponseEntity.ok(SuccessResponse.successWithData(sollectSearchContents));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryCustom.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryCustom.java
@@ -20,4 +20,7 @@ public interface SollectRepositoryCustom {
 
   List<SollectSearchResponseContent> searchSollectBySollectIdsAndCursor(
       Long cursorId, int size, List<Long> sollectIds);
+
+  List<SollectSearchResponseContent> searchRecommendSollectByKeywordOrCategory(
+      String keyword, String categoryName);
 }

--- a/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryImpl.java
+++ b/src/main/java/com/ilta/solepli/domain/sollect/repository/SollectRepositoryImpl.java
@@ -206,6 +206,8 @@ public class SollectRepositoryImpl implements SollectRepositoryCustom {
       condition.and(matchSollectTitle(keyword).or(matchSollectText(keyword)));
     }
 
+    QSolmarkSollect solmark = QSolmarkSollect.solmarkSollect;
+
     // 해당 조건에 해당하고, 쏠마크가 많은 쏠렉트 아이디 8개 추출
     List<Long> sollectIds =
         queryFactory
@@ -214,11 +216,11 @@ public class SollectRepositoryImpl implements SollectRepositoryCustom {
             .leftJoin(sollect.sollectContents, sollectContent)
             .leftJoin(sollect.sollectPlaces, sollectPlace)
             .leftJoin(sollectPlace.place, place)
-            .leftJoin(solmarkSollect, solmarkSollect)
-            .on(solmarkSollect.sollect.eq(sollect))
+            .leftJoin(solmark)
+            .on(solmark.sollect.eq(sollect))
             .where(condition, sollect.deletedAt.isNull())
             .groupBy(sollect.id)
-            .orderBy(solmarkSollect.id.count().desc())
+            .orderBy(solmark.id.count().desc())
             .limit(8)
             .fetch();
 
@@ -273,6 +275,6 @@ public class SollectRepositoryImpl implements SollectRepositoryCustom {
     return sollectContent
         .type
         .eq(ContentType.TEXT)
-        .and(sollectContent.text.containsIgnoreCase(keyword));
+        .and(sollectContent.text.stringValue().like("%" + keyword + "%"));
   }
 }

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -59,8 +59,9 @@ public class SecurityConfig {
                         "/api/solmap/places/nearby",
                         "/api/solmap/place/*/reviews",
                         "/api/place/search",
-                        "api/solroute/place/nearby/*",
-                        "/api/solroute/place/*")
+                        "/api/solroute/place/nearby/*",
+                        "/api/solroute/place/*",
+                        "/api/sollect/recommend")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/sollect/*")
                     .permitAll()


### PR DESCRIPTION
## #️⃣ Issue Number
#83
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
추천 쏠렉트 조회 기능 구현 완료했습니다.

카테고리에 해당하는 장소 아이디를 추출하고,
```
List<Long> placeIds =
        queryFactory
            .select(place.id)
            .from(place)
            .leftJoin(place.placeCategories, placeCategory)
            .leftJoin(placeCategory.category, category)
            .where(matchCategory(categoryName))
            .fetch();
```

다음과 같이 조건을 만든 후
```
BooleanBuilder condition = new BooleanBuilder();

    if (!placeIds.isEmpty()) condition.and(sollectPlace.place.id.in(placeIds));

    // 선택 키워드 조건 (Sollect.title 또는 SollectContent.text(TEXT 타입만))
    if (keyword != null && !keyword.isBlank()) {
      condition.and(matchSollectTitle(keyword).or(matchSollectText(keyword)));
    }

```

해당 조건에 해당하고, 쏠마크가 많은 쏠렉트 아이디 8개 추출하여 DTO를 생성하였습니다.
```
List<Long> sollectIds =
        queryFactory
            .select(sollect.id)
            .from(sollect)
            .leftJoin(sollect.sollectContents, sollectContent)
            .leftJoin(sollect.sollectPlaces, sollectPlace)
            .leftJoin(sollectPlace.place, place)
            .leftJoin(solmark)
            .on(solmark.sollect.eq(sollect))
            .where(condition, sollect.deletedAt.isNull())
            .groupBy(sollect.id)
            .orderBy(solmark.id.count().desc())
            .limit(8)
            .fetch();
```

DTO를 생성할 때, `IN`을 이용해서 순서 보장이 안되므로, HashMap을 이용하여 재정렬하여 결과를 리턴했습니다.
```
Map<Long, Integer> orderMap = new HashMap<>();
    for (int i = 0; i < sollectIds.size(); i++) {
      orderMap.put(sollectIds.get(i), i); // ID를 key로, 순서를 value로 저장
    }

results.sort(Comparator.comparingInt(dto -> orderMap.get(dto.sollectId())));
return results; 
```
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
