### PR TITLE
Feat: 쏠루트 코스 프리뷰 조회 기능 구현 (#92)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solroute/controller/SolrouteController.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/controller/SolrouteController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,5 +64,15 @@ public class SolrouteController {
     PlacePreviewResponse placePreview = solrouteService.getPlacePreview(placeId);
 
     return ResponseEntity.ok(SuccessResponse.successWithData(placePreview));
+  }
+
+  @Operation(summary = "쏠루트 코스 상태 변경 API", description = "쏠루트 코스의 상태를 변경할때 사용하는 API입니다.")
+  @PatchMapping("/{solrotueId}")
+  public ResponseEntity<SuccessResponse<Void>> updateSolrouteStatus(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable Long solrotueId) {
+
+    String status = solrouteService.updateSolrouteStatus(solrotueId, customUserDetails.user());
+    return ResponseEntity.status(200)
+        .body(SuccessResponse.successWithNoData("쏠루트 상태 " + status + "(으)로 변경 완료."));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solroute/controller/SolrouteController.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/controller/SolrouteController.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import com.ilta.solepli.domain.solroute.dto.request.SolrouteCreateRequest;
 import com.ilta.solepli.domain.solroute.dto.response.PlacePreviewResponse;
 import com.ilta.solepli.domain.solroute.dto.response.PlaceSummaryResponse;
+import com.ilta.solepli.domain.solroute.dto.response.SolroutePreviewResponse;
 import com.ilta.solepli.domain.solroute.service.SolrouteService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
 import com.ilta.solepli.global.response.SuccessResponse;
@@ -40,7 +41,7 @@ public class SolrouteController {
 
     solrouteService.createSolroute(customUserDetails.user(), request);
 
-    return ResponseEntity.status(200).body(SuccessResponse.successWithNoData("쏠루트 생성 완료."));
+    return ResponseEntity.status(200).body(SuccessResponse.successWithNoData("쏠루트 생성 완료"));
   }
 
   @Operation(summary = "추가한 장소 근처 인기 장소 조회 API", description = "추가한 장소 근처 인기 장소 조회 API입니다.")
@@ -73,6 +74,15 @@ public class SolrouteController {
 
     String status = solrouteService.updateSolrouteStatus(solrotueId, customUserDetails.user());
     return ResponseEntity.status(200)
-        .body(SuccessResponse.successWithNoData("쏠루트 상태 " + status + "(으)로 변경 완료."));
+        .body(SuccessResponse.successWithNoData("쏠루트 상태 " + status + "(으)로 변경 완료"));
+  }
+
+  @Operation(summary = "쏠루트 코스 프리뷰 조회 API", description = "쏠루트 코스 프리뷰 리스트를 조회할 때 사용하는 API입니다.")
+  @GetMapping
+  public ResponseEntity<SuccessResponse<List<SolroutePreviewResponse>>> getSolroutePreviews(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    List<SolroutePreviewResponse> solroutePreviews =
+        solrouteService.getSolroutePreviews(customUserDetails.user());
+    return ResponseEntity.ok(SuccessResponse.successWithData(solroutePreviews));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solroute/controller/SolrouteController.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/controller/SolrouteController.java
@@ -67,7 +67,7 @@ public class SolrouteController {
   }
 
   @Operation(summary = "쏠루트 코스 상태 변경 API", description = "쏠루트 코스의 상태를 변경할때 사용하는 API입니다.")
-  @PatchMapping("/{solrotueId}")
+  @PatchMapping("/{solrotueId}/status")
   public ResponseEntity<SuccessResponse<Void>> updateSolrouteStatus(
       @AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable Long solrotueId) {
 

--- a/src/main/java/com/ilta/solepli/domain/solroute/dto/response/SolroutePreviewResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/dto/response/SolroutePreviewResponse.java
@@ -1,0 +1,19 @@
+package com.ilta.solepli.domain.solroute.dto.response;
+
+import lombok.Builder;
+
+import com.ilta.solepli.domain.solroute.entity.Solroute;
+
+@Builder
+public record SolroutePreviewResponse(
+    Long id, Integer iconId, String name, Integer placeCount, String status) {
+  public static SolroutePreviewResponse from(Solroute solroute) {
+    return SolroutePreviewResponse.builder()
+        .id(solroute.getId())
+        .name(solroute.getName())
+        .iconId(solroute.getIconId())
+        .placeCount(solroute.getSolroutePlaces().size())
+        .status(solroute.getStatus().getDescription())
+        .build();
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/solroute/entity/Solroute.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/entity/Solroute.java
@@ -56,6 +56,7 @@ public class Solroute extends Timestamped {
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
+  @Builder.Default
   private SolrouteStatus status = SolrouteStatus.SCHEDULED;
 
   public void addSolroutePlace(SolroutePlace solroutePlace) {

--- a/src/main/java/com/ilta/solepli/domain/solroute/entity/Solroute.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/entity/Solroute.java
@@ -6,6 +6,8 @@ import java.util.List;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -52,8 +54,16 @@ public class Solroute extends Timestamped {
   @Builder.Default
   private List<SolroutePlace> solroutePlaces = new ArrayList<>();
 
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private SolrouteStatus status = SolrouteStatus.SCHEDULED;
+
   public void addSolroutePlace(SolroutePlace solroutePlace) {
     solroutePlaces.add(solroutePlace);
     solroutePlace.setSolroute(this);
+  }
+
+  public void updateStatus() {
+    this.status = this.status.update();
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solroute/entity/Solroute.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/entity/Solroute.java
@@ -63,7 +63,8 @@ public class Solroute extends Timestamped {
     solroutePlace.setSolroute(this);
   }
 
-  public void updateStatus() {
+  public String updateStatus() {
     this.status = this.status.update();
+    return this.status.getDescription();
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solroute/entity/SolrouteStatus.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/entity/SolrouteStatus.java
@@ -1,0 +1,20 @@
+package com.ilta.solepli.domain.solroute.entity;
+
+public enum SolrouteStatus {
+  SCHEDULED("예정"),
+  COMPLETED("완료");
+
+  private final String description;
+
+  SolrouteStatus(String description) {
+    this.description = description;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public SolrouteStatus update() {
+    return this == SCHEDULED ? COMPLETED : SCHEDULED;
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/solroute/repository/SolrouteRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/repository/SolrouteRepository.java
@@ -1,7 +1,14 @@
 package com.ilta.solepli.domain.solroute.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.ilta.solepli.domain.solroute.entity.Solroute;
+import com.ilta.solepli.domain.user.entity.User;
 
-public interface SolrouteRepository extends JpaRepository<Solroute, Long> {}
+public interface SolrouteRepository extends JpaRepository<Solroute, Long> {
+  @Query("SELECT s FROM Solroute s WHERE s.id = :id AND s.user = :user AND s.deletedAt IS NULL")
+  Optional<Solroute> findByIdAndUser(Long id, User user);
+}

--- a/src/main/java/com/ilta/solepli/domain/solroute/repository/SolrouteRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/repository/SolrouteRepository.java
@@ -1,7 +1,9 @@
 package com.ilta.solepli.domain.solroute.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,4 +13,8 @@ import com.ilta.solepli.domain.user.entity.User;
 public interface SolrouteRepository extends JpaRepository<Solroute, Long> {
   @Query("SELECT s FROM Solroute s WHERE s.id = :id AND s.user = :user AND s.deletedAt IS NULL")
   Optional<Solroute> findByIdAndUser(Long id, User user);
+
+  @EntityGraph(attributePaths = {"solroutePlaces"})
+  @Query("SELECT s FROM Solroute s WHERE s.user = :user AND s.deletedAt IS NULL")
+  List<Solroute> findAllByUserId(User user);
 }

--- a/src/main/java/com/ilta/solepli/domain/solroute/service/SolrouteService.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/service/SolrouteService.java
@@ -137,6 +137,13 @@ public class SolrouteService {
         .build();
   }
 
+  @Transactional
+  public String updateSolrouteStatus(Long solrouteId, User user) {
+    Solroute solroute = getSolrouteOrThrow(solrouteId, user);
+
+    return solroute.updateStatus();
+  }
+
   private Set<Long> getSolmarkedPlaceIds(User user, List<Place> places) {
     // 비로그인이거나 조회된 장소가 없으면 빈 Set 반환
     if (user == null & places.isEmpty()) {
@@ -151,5 +158,11 @@ public class SolrouteService {
 
     // 쏠마크 장소 ID Set 반환
     return solmarkPlaces.stream().map(sp -> sp.getPlace().getId()).collect(Collectors.toSet());
+  }
+
+  private Solroute getSolrouteOrThrow(Long solrouteId, User user) {
+    return solrouteRepository
+        .findByIdAndUser(solrouteId, user)
+        .orElseThrow(() -> new CustomException(ErrorCode.SOLROUTE_ACCESS_DENIED));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solroute/service/SolrouteService.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/service/SolrouteService.java
@@ -21,6 +21,7 @@ import com.ilta.solepli.domain.solroute.dto.request.SolrouteCreateRequest;
 import com.ilta.solepli.domain.solroute.dto.request.SolrouteCreateRequest.PlaceInfo;
 import com.ilta.solepli.domain.solroute.dto.response.PlacePreviewResponse;
 import com.ilta.solepli.domain.solroute.dto.response.PlaceSummaryResponse;
+import com.ilta.solepli.domain.solroute.dto.response.SolroutePreviewResponse;
 import com.ilta.solepli.domain.solroute.entity.Solroute;
 import com.ilta.solepli.domain.solroute.entity.SolroutePlace;
 import com.ilta.solepli.domain.solroute.repository.SolroutePlaceRepository;
@@ -142,6 +143,13 @@ public class SolrouteService {
     Solroute solroute = getSolrouteOrThrow(solrouteId, user);
 
     return solroute.updateStatus();
+  }
+
+  @Transactional(readOnly = true)
+  public List<SolroutePreviewResponse> getSolroutePreviews(User user) {
+    return solrouteRepository.findAllByUserId(user).stream()
+        .map(SolroutePreviewResponse::from)
+        .toList();
   }
 
   private Set<Long> getSolmarkedPlaceIds(User user, List<Place> places) {

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -84,7 +84,11 @@ public enum ErrorCode {
 
   // 쏠마크 - 장소 관련 에러
   COLLECTION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "저장 리스트는 최대 50개까지만 생성할 수 있습니다."),
-  COLLECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 저장 리스트 입니다.");
+  COLLECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 저장 리스트 입니다."),
+
+  // 쏠루트 관련 에러
+  SOLROUTE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없거나 Solroute가 존재하지 않습니다.");
+  ;
 
   private final HttpStatus httpStatus;
   private final String message;


### PR DESCRIPTION
## #️⃣ Issue Number
#92
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
쏠루트 코스 프리뷰 조회 기능 구현 완료했습니다.
"예정", "완료"를 나타내는 상태 필드 추가했고, 쏠루트 프리뷰 조회할 때, 추후 Soft Delete를 고려하여 `deletedAt`이 null인 쏠루트만 조회 했습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

