### PR TITLE
Feat: 쏠마크 - 장소 추가 및 삭제 기능 구현 (#91)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
@@ -12,9 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import com.ilta.solepli.domain.solmark.place.dto.reqeust.AddSolmarkPlaceRequest;
-import com.ilta.solepli.domain.solmark.place.dto.reqeust.CreateCollectionRequest;
-import com.ilta.solepli.domain.solmark.place.dto.reqeust.UpdateCollectionRequest;
+import com.ilta.solepli.domain.solmark.place.dto.reqeust.*;
 import com.ilta.solepli.domain.solmark.place.dto.response.CollectionResponse;
 import com.ilta.solepli.domain.solmark.place.dto.response.SolmarkPlacesResponse;
 import com.ilta.solepli.domain.solmark.place.service.SolmarkPlaceService;
@@ -39,18 +37,6 @@ public class SolmarkPlaceController {
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(SuccessResponse.successWithNoData("쏠마크 저장 리스트 추가 성공"));
-  }
-
-  @Operation(summary = "쏠마크 장소 추가 API", description = "쏠마크 장소 저장 리스트 추가 API 입니다.")
-  @PostMapping("")
-  public ResponseEntity<SuccessResponse<Void>> addSolmarkPlace(
-      @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @RequestBody AddSolmarkPlaceRequest addSolmarkPlaceRequest) {
-
-    solmarkPlaceService.addSolmarkPlace(customUserDetails, addSolmarkPlaceRequest);
-
-    return ResponseEntity.status(HttpStatus.CREATED)
-        .body(SuccessResponse.successWithNoData("쏠마크 장소 추가 성공"));
   }
 
   @Operation(summary = "쏠마크 장소 저장 리스트 조회 API", description = "쏠마크 장소 저장 리스트 조회 API 입니다.")

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/controller/SolmarkPlaceController.java
@@ -83,4 +83,17 @@ public class SolmarkPlaceController {
 
     return ResponseEntity.ok().body(SuccessResponse.successWithNoData("쏠마크 저장 리스트 삭제 성공"));
   }
+
+  @Operation(summary = "쏠마크 장소 추가 및 삭제 API", description = "쏠마크 장소 추가 및 삭제 API 입니다.")
+  @PatchMapping("/{placeId}/collections")
+  public ResponseEntity<SuccessResponse<Void>> updatePlaceCollections(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable Long placeId,
+      @RequestBody UpdatePlaceCollectionsRequest updatePlaceCollectionsRequest) {
+
+    solmarkPlaceService.updatePlaceCollections(
+        customUserDetails, placeId, updatePlaceCollectionsRequest);
+
+    return ResponseEntity.ok().body(SuccessResponse.successWithNoData("쏠마크 장소 업데이트 성공"));
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/dto/CollectionCountDto.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/dto/CollectionCountDto.java
@@ -1,0 +1,3 @@
+package com.ilta.solepli.domain.solmark.place.dto;
+
+public record CollectionCountDto(Long collectionId, Long count) {}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/dto/reqeust/AddSolmarkPlaceRequest.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/dto/reqeust/AddSolmarkPlaceRequest.java
@@ -1,5 +1,0 @@
-package com.ilta.solepli.domain.solmark.place.dto.reqeust;
-
-import java.util.List;
-
-public record AddSolmarkPlaceRequest(List<Long> collectionIds, Long placeId) {}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/dto/reqeust/UpdatePlaceCollectionsRequest.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/dto/reqeust/UpdatePlaceCollectionsRequest.java
@@ -1,0 +1,6 @@
+package com.ilta.solepli.domain.solmark.place.dto.reqeust;
+
+import java.util.List;
+
+public record UpdatePlaceCollectionsRequest(
+    List<Long> addCollectionIds, List<Long> removeCollectionIds) {}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceCollectionRepository.java
@@ -41,4 +41,41 @@ public interface SolmarkPlaceCollectionRepository
     AND spc.deletedAt IS NULL
 """)
   Optional<SolmarkPlaceCollection> findByIdAndUser(Long id, User user);
+
+  @Query(
+      """
+    SELECT spc
+    FROM SolmarkPlaceCollection spc
+    WHERE spc.user = :user
+    AND spc.id IN :collectionIds
+    AND spc.deletedAt IS NULL
+""")
+  List<SolmarkPlaceCollection> findByUserAndIdInAndDeletedAtIsNull(
+      User user, List<Long> collectionIds);
+
+  @Query(
+      """
+    SELECT spc
+    FROM SolmarkPlaceCollection spc
+    JOIN FETCH spc.solmarkPlaces sp
+    WHERE spc.user = :user
+    AND spc.id IN :collectionIds
+    AND spc.deletedAt IS NULL
+""")
+  List<SolmarkPlaceCollection> findByUserAndIdInAndDeletedAtIsNullWithPlaces(
+      User user, List<Long> collectionIds);
+
+  @Query(
+      """
+    SELECT spc.id
+    FROM SolmarkPlace sp
+    JOIN sp.solmarkPlaceCollection spc
+    JOIN sp.place p
+    WHERE spc.user = :user
+    AND p.id = :placeId
+    AND sp.deletedAt IS NULL
+    AND spc.deletedAt IS NULL
+
+""")
+  List<Long> findByUserAndPlaceId(User user, Long placeId);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.ilta.solepli.domain.place.entity.Place;
+import com.ilta.solepli.domain.solmark.place.dto.CollectionCountDto;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlace;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
 import com.ilta.solepli.domain.user.entity.User;
@@ -39,4 +40,14 @@ public interface SolmarkPlaceRepository extends JpaRepository<SolmarkPlace, Long
     AND spc.id = :collectionId
 """)
   List<SolmarkPlace> findByUserAndCollectionId(User user, Long collectionId);
+
+  @Query(
+      """
+    SELECT new com.ilta.solepli.domain.solmark.place.dto.CollectionCountDto(sp.solmarkPlaceCollection.id, COUNT(*))
+    FROM SolmarkPlace sp
+    WHERE sp.solmarkPlaceCollection.id IN :collectionIds
+    AND sp.deletedAt IS NULL
+    GROUP BY sp.solmarkPlaceCollection.id
+""")
+  List<CollectionCountDto> countByCollectionIds(List<Long> collectionIds);
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -21,6 +21,7 @@ import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceCollectionRe
 import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceRepository;
 import com.ilta.solepli.domain.user.entity.User;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
+import com.ilta.solepli.global.entity.Timestamped;
 import com.ilta.solepli.global.exception.CustomException;
 import com.ilta.solepli.global.exception.ErrorCode;
 import com.ilta.solepli.global.util.PlaceUtil;
@@ -153,5 +154,92 @@ public class SolmarkPlaceService {
         .findByIdAndUser(collectionId, user)
         .orElseThrow(() -> new CustomException(ErrorCode.COLLECTION_NOT_FOUND))
         .softDelete(); // delete 시점 기록
+  }
+
+  @Transactional
+  public void updatePlaceCollections(
+      CustomUserDetails customUserDetails, Long placeId, UpdatePlaceCollectionsRequest req) {
+    User user = customUserDetails.user();
+
+    // 장소 조회
+    Place place =
+        placeRepository
+            .findById(placeId)
+            .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_EXISTS));
+
+    // 추가/삭제할 저장 리스트 ID 리스트 (null 방지)
+    List<Long> addCollectionIds =
+        req.addCollectionIds() == null ? List.of() : req.addCollectionIds();
+    List<Long> removeCollectionIds =
+        req.removeCollectionIds() == null ? List.of() : req.removeCollectionIds();
+
+    // 현재 사용자가 해당 장소를 마크한 저장 리스트 ID Set 조회
+    Set<Long> existingIdSet =
+        new HashSet<>(solmarkPlaceCollectionRepository.findByUserAndPlaceId(user, placeId));
+
+    // 실제로 추가해야 할 저장 리스트 ID 리스트
+    List<Long> toAdd = filterToAdd(addCollectionIds, existingIdSet);
+    // 실제로 soft-delete 해야 할 저장 리스트 ID 리스트
+    List<Long> toRemove = filterToRemove(removeCollectionIds, existingIdSet);
+
+    // 저장 리스트별 장소 개수 제한 검증
+    validateCollectionPlaceLimit(toAdd);
+
+    // 쏠마크 장소 추가
+    addSolmarkPlace(user, toAdd, place);
+    // 쏠마크 장소 삭제(softDelete)
+    softDeleteSolmarkPlace(user, toRemove, place);
+  }
+
+  /** 지정한 저장 리스트에서 해당 장소에 대한 쏠마크를 soft-delete 처리 */
+  private void softDeleteSolmarkPlace(User user, List<Long> toRemove, Place place) {
+    if (toRemove.isEmpty()) return;
+    List<SolmarkPlaceCollection> removeCollections =
+        solmarkPlaceCollectionRepository.findByUserAndIdInAndDeletedAtIsNullWithPlaces(
+            user, toRemove);
+
+    removeCollections.forEach(
+        c -> {
+          c.getSolmarkPlaces().stream()
+              .filter(sp -> sp.getPlace().equals(place) && sp.getDeletedAt() == null)
+              .forEach(Timestamped::softDelete);
+        });
+  }
+
+  /** 지정한 저장 리스트에 해당 장소를 쏠마크로 추가 */
+  private void addSolmarkPlace(User user, List<Long> toAdd, Place place) {
+    if (toAdd.isEmpty()) return;
+    List<SolmarkPlaceCollection> addCollections =
+        solmarkPlaceCollectionRepository.findByUserAndIdInAndDeletedAtIsNull(user, toAdd);
+
+    List<SolmarkPlace> addSolmarkPlaces =
+        addCollections.stream()
+            .map(c -> SolmarkPlace.builder().solmarkPlaceCollection(c).place(place).build())
+            .toList();
+
+    solmarkPlaceRepository.saveAll(addSolmarkPlaces);
+  }
+
+  /** 저장 리스트별 장소 개수 제한 검증 (최대 개수 초과 시 예외 발생) */
+  private void validateCollectionPlaceLimit(List<Long> toAdd) {
+    List<CollectionCountDto> collectionCountDtos =
+        solmarkPlaceRepository.countByCollectionIds(toAdd);
+
+    collectionCountDtos.forEach(
+        dto -> {
+          if (dto.count() >= MAX_PLACES_PER_COLLECTION) {
+            throw new CustomException(ErrorCode.EXCEEDED_MARK_PLACE_LIMIT);
+          }
+        });
+  }
+
+  /** 삭제 대상 저장 리스트 ID만 필터링 */
+  private List<Long> filterToRemove(List<Long> removeCollectionIds, Set<Long> existingIdSet) {
+    return removeCollectionIds.stream().filter(existingIdSet::contains).toList();
+  }
+
+  /** 추가 대상 저장 리스트 ID만 필터링 */
+  private List<Long> filterToAdd(List<Long> addCollectionIds, Set<Long> existingIdSet) {
+    return addCollectionIds.stream().filter(id -> !existingIdSet.contains(id)).toList();
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -1,6 +1,6 @@
 package com.ilta.solepli.domain.solmark.place.service;
 
-import java.util.List;
+import java.util.*;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,9 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.place.repository.PlaceRepository;
-import com.ilta.solepli.domain.solmark.place.dto.reqeust.AddSolmarkPlaceRequest;
-import com.ilta.solepli.domain.solmark.place.dto.reqeust.CreateCollectionRequest;
-import com.ilta.solepli.domain.solmark.place.dto.reqeust.UpdateCollectionRequest;
+import com.ilta.solepli.domain.solmark.place.dto.CollectionCountDto;
+import com.ilta.solepli.domain.solmark.place.dto.reqeust.*;
 import com.ilta.solepli.domain.solmark.place.dto.response.CollectionResponse;
 import com.ilta.solepli.domain.solmark.place.dto.response.SolmarkPlaceDto;
 import com.ilta.solepli.domain.solmark.place.dto.response.SolmarkPlacesResponse;
@@ -62,61 +61,6 @@ public class SolmarkPlaceService {
             .build();
 
     solmarkPlaceCollectionRepository.save(placeCollection);
-  }
-
-  @Transactional
-  public void addSolmarkPlace(
-      CustomUserDetails customUserDetails, AddSolmarkPlaceRequest addSolmarkPlaceRequest) {
-    User user = customUserDetails.user();
-    List<Long> collectionIds = addSolmarkPlaceRequest.collectionIds();
-    // 추가할 장소 조회
-    Place place =
-        placeRepository
-            .findById(addSolmarkPlaceRequest.placeId())
-            .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_EXISTS));
-
-    // 요청 데이터 collectionIds를 기반으로 사용자 쏠마크 저장 리스트 조회
-    List<SolmarkPlaceCollection> collections = validateAndGetCollections(user, collectionIds);
-
-    // 추가할 저장 리스트에 이미 저장된 장소인지 검증
-    validateCollectionPlaceDuplicate(collections, place);
-
-    // 조회한 쏠마크 저장 리스트에 추가할 SolmarkPlace 객체 리스트
-    List<SolmarkPlace> solmarkPlaces =
-        collections.stream()
-            .map(
-                c -> {
-                  // 각 장소 리스트별 최대 장소 저장 개수 검증
-                  validateCollectionPlaceLimit(c);
-
-                  return SolmarkPlace.builder().solmarkPlaceCollection(c).place(place).build();
-                })
-            .toList();
-
-    solmarkPlaceRepository.saveAll(solmarkPlaces);
-  }
-
-  private List<SolmarkPlaceCollection> validateAndGetCollections(User user, List<Long> ids) {
-    List<SolmarkPlaceCollection> cols =
-        solmarkPlaceCollectionRepository.findByUserAndId_In(user, ids);
-    // 저장 리스트 ID 검증
-    if (cols.size() != ids.size()) {
-      throw new CustomException(ErrorCode.COLLECTION_NOT_FOUND);
-    }
-    return cols;
-  }
-
-  private void validateCollectionPlaceLimit(SolmarkPlaceCollection c) {
-    if (c.getSolmarkPlaces().size() >= MAX_PLACES_PER_COLLECTION) {
-      throw new CustomException(ErrorCode.EXCEEDED_MARK_PLACE_LIMIT);
-    }
-  }
-
-  private void validateCollectionPlaceDuplicate(
-      List<SolmarkPlaceCollection> collections, Place place) {
-    if (solmarkPlaceRepository.existsBySolmarkPlaceCollectionInAndPlace(collections, place)) {
-      throw new CustomException(ErrorCode.DUPLICATED_MARK_PLACE);
-    }
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#91 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 이전에 쏠마크 - 장소 추가 API를 삭제하고 추가와 삭제 기능을 하는 API를 구현하였습니다.
- 쏠마크 장소 추가 API를 삭제하고 추가 및 삭제 API를 구현한 이유는 아래 사진처럼 여러 저장 리스트에 삭제와 추가가 가능한데 추가 API와 삭제 API를 나누게 되면 하나의 트랜잭션에서 실행이 불가능하기 때문에 추가와 삭제를 하나의 트랜잭션에 할수 있도록 하나의 API로 구현하였습니다.
![image](https://github.com/user-attachments/assets/25b47bd6-836a-471a-bf88-63b5182a5bae)


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 파일 혹은 폴더 삭제
