### PR TITLE
Feat: 쏠루트 코스 상세조회 기능 구현 (#95)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solroute/controller/SolrouteController.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/controller/SolrouteController.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import com.ilta.solepli.domain.solroute.dto.request.SolrouteCreateRequest;
 import com.ilta.solepli.domain.solroute.dto.response.PlacePreviewResponse;
 import com.ilta.solepli.domain.solroute.dto.response.PlaceSummaryResponse;
+import com.ilta.solepli.domain.solroute.dto.response.SolrouteDetailResponse;
 import com.ilta.solepli.domain.solroute.dto.response.SolroutePreviewResponse;
 import com.ilta.solepli.domain.solroute.service.SolrouteService;
 import com.ilta.solepli.domain.user.util.CustomUserDetails;
@@ -84,5 +85,16 @@ public class SolrouteController {
     List<SolroutePreviewResponse> solroutePreviews =
         solrouteService.getSolroutePreviews(customUserDetails.user());
     return ResponseEntity.ok(SuccessResponse.successWithData(solroutePreviews));
+  }
+
+  @Operation(summary = "쏠루트 코스 상세조회 API", description = "쏠루트 코스를 상세 조회할 때 사용하는 API입니다.")
+  @GetMapping({"/{solrotueId}"})
+  public ResponseEntity<SuccessResponse<SolrouteDetailResponse>> getSolrouteDetail(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable Long solrotueId) {
+
+    SolrouteDetailResponse response =
+        solrouteService.getSolrouteDeatil(solrotueId, customUserDetails.user());
+
+    return ResponseEntity.ok(SuccessResponse.successWithData(response));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/solroute/dto/response/SolrouteDetailResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/dto/response/SolrouteDetailResponse.java
@@ -1,0 +1,38 @@
+package com.ilta.solepli.domain.solroute.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+
+import com.ilta.solepli.domain.solroute.entity.SolroutePlace;
+
+@Builder
+public record SolrouteDetailResponse(
+    Long id,
+    Integer iconId,
+    String name,
+    Integer placeCount,
+    String status,
+    List<PlaceInfo> placeInfos) {
+  @Builder
+  public record PlaceInfo(
+      Integer seq,
+      String placeName,
+      String detailedCategory,
+      String address,
+      String memo,
+      Double latitude,
+      Double longitude) {
+    public static PlaceInfo from(SolroutePlace solroutePlace) {
+      return PlaceInfo.builder()
+          .seq(solroutePlace.getSeq())
+          .placeName(solroutePlace.getPlace().getName())
+          .detailedCategory(solroutePlace.getPlace().getTypes())
+          .address(solroutePlace.getPlace().getAddress())
+          .memo(solroutePlace.getMemo())
+          .latitude(solroutePlace.getPlace().getLatitude())
+          .longitude(solroutePlace.getPlace().getLongitude())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/solroute/repository/SolrouteRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/repository/SolrouteRepository.java
@@ -14,6 +14,10 @@ public interface SolrouteRepository extends JpaRepository<Solroute, Long> {
   @Query("SELECT s FROM Solroute s WHERE s.id = :id AND s.user = :user AND s.deletedAt IS NULL")
   Optional<Solroute> findByIdAndUser(Long id, User user);
 
+  @EntityGraph(attributePaths = {"solroutePlaces", "solroutePlaces.place"})
+  @Query("SELECT s FROM Solroute s WHERE s.id = :id AND s.user = :user AND s.deletedAt IS NULL")
+  Optional<Solroute> findByIdAndUserWithPlaces(Long id, User user);
+
   @EntityGraph(attributePaths = {"solroutePlaces"})
   @Query("SELECT s FROM Solroute s WHERE s.user = :user AND s.deletedAt IS NULL")
   List<Solroute> findAllByUserId(User user);


### PR DESCRIPTION
## #️⃣ Issue Number
#95
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
쏠루트 코스 상세조회 기능 구현했습니다.

응답을 생성하는데 SolroutePlace뿐만 아니라 SolroutePlace.Place도 필요하므로
```
@EntityGraph(attributePaths = {"solroutePlaces", "solroutePlaces.place"})
@Query("SELECT s FROM Solroute s WHERE s.id = :id AND s.user = :user AND s.deletedAt IS NULL")
Optional<Solroute> findByIdAndUserWithPlaces(Long id, User user);
```
다음과 같은 쿼리를 사용하여 진행했습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

