### PR TITLE
Refactor: 인증 관련 기능 리팩토링 (#99)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/auth/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/filter/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package com.ilta.solepli.domain.auth.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.ilta.solepli.global.exception.ErrorCode;
+import com.ilta.solepli.global.util.ResponseUtil;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException {
+
+    ResponseUtil.writeError(response, ErrorCode.UNAUTHORIZED);
+  }
+}

--- a/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
@@ -51,6 +51,7 @@ public class AuthService {
                 .password(passwordEncoder.encode(request.password()))
                 .profileImageUrl(defaultImageUrl)
                 .nickname(userService.generateAdminNickname())
+                .loginType(LoginType.BASIC)
                 .build());
 
     SolmarkPlaceCollection solmarkPlaceCollection =
@@ -88,7 +89,7 @@ public class AuthService {
 
     String loginId = oauthService.getLoginId(oauthService.getAccessToken(code));
 
-    User findUser = userService.findOrSignUpUser(loginId);
+    User findUser = userService.findOrSignUpUser(loginId, loginType);
 
     String accessToken = jwtTokenProvider.generateToken(findUser);
 

--- a/src/main/java/com/ilta/solepli/domain/auth/service/JwtTokenProvider.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/JwtTokenProvider.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -38,25 +37,5 @@ public class JwtTokenProvider {
         .setExpiration(expiry)
         .signWith(key, SignatureAlgorithm.HS256)
         .compact();
-  }
-
-  public String getLoginIdFromToken(String token) {
-    // 토큰에서 사용자 ID 추출
-    return Jwts.parserBuilder()
-        .setSigningKey(key)
-        .build()
-        .parseClaimsJws(token)
-        .getBody()
-        .getSubject();
-  }
-
-  public boolean validateToken(String token) {
-    try {
-      // 토큰 파싱 → 유효한 경우 true
-      Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-      return true;
-    } catch (JwtException e) {
-      return false;
-    }
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/user/entity/User.java
+++ b/src/main/java/com/ilta/solepli/domain/user/entity/User.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.ilta.solepli.domain.auth.entity.LoginType;
 import com.ilta.solepli.global.entity.Timestamped;
 
 @Entity
@@ -42,4 +43,8 @@ public class User extends Timestamped {
 
   @Column(unique = true)
   private String nickname;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private LoginType loginType;
 }

--- a/src/main/java/com/ilta/solepli/domain/user/service/UserService.java
+++ b/src/main/java/com/ilta/solepli/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.ilta.solepli.domain.auth.entity.LoginType;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlaceCollection;
 import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceCollectionRepository;
 import com.ilta.solepli.domain.user.entity.Role;
@@ -58,7 +59,7 @@ public class UserService {
   }
 
   @Transactional
-  public User findOrSignUpUser(String loginId) {
+  public User findOrSignUpUser(String loginId, LoginType loginType) {
 
     Random random = new Random();
     String nickname;
@@ -83,6 +84,7 @@ public class UserService {
                           .loginId(loginId)
                           .profileImageUrl(defaultImageUrl)
                           .nickname(checkedNickname)
+                          .loginType(loginType)
                           .build());
 
               SolmarkPlaceCollection solmarkPlaceCollection =

--- a/src/main/java/com/ilta/solepli/domain/user/util/CustomUserDetails.java
+++ b/src/main/java/com/ilta/solepli/domain/user/util/CustomUserDetails.java
@@ -13,7 +13,7 @@ public record CustomUserDetails(User user) implements UserDetails {
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return Collections.singleton(new SimpleGrantedAuthority(user.getRole().toString())); // 역할 권한 설정
+    return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
   }
 
   @Override

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import com.ilta.solepli.domain.auth.filter.JwtAuthenticationEntryPoint;
 import com.ilta.solepli.domain.auth.filter.JwtAuthenticationFilter;
 import com.ilta.solepli.domain.user.util.CustomUserDetailService;
+import com.ilta.solepli.global.exception.handler.JwtAccessDeniedHandler;
 import com.ilta.solepli.global.util.JwtUtil;
 
 @Configuration
@@ -30,6 +31,7 @@ public class SecurityConfig {
 
   private final JwtUtil jwtUtil;
   private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+  private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
   private final CustomUserDetailService customUserDetailService;
 
   @Bean
@@ -37,7 +39,10 @@ public class SecurityConfig {
     return http.csrf(csrf -> csrf.disable()) // JWT 기반 인증이라 CSRF 비활성화
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+        .exceptionHandling(
+            ex ->
+                ex.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                    .accessDeniedHandler(jwtAccessDeniedHandler))
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -16,16 +16,18 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
 
+import com.ilta.solepli.domain.auth.filter.JwtAuthenticationEntryPoint;
 import com.ilta.solepli.domain.auth.filter.JwtAuthenticationFilter;
-import com.ilta.solepli.domain.auth.service.JwtTokenProvider;
 import com.ilta.solepli.domain.user.util.CustomUserDetailService;
+import com.ilta.solepli.global.util.JwtUtil;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
 
-  private final JwtTokenProvider jwtTokenProvider;
+  private final JwtUtil jwtUtil;
+  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
   private final CustomUserDetailService customUserDetailService;
 
   @Bean
@@ -33,6 +35,7 @@ public class SecurityConfig {
     return http.csrf(csrf -> csrf.disable()) // JWT 기반 인증이라 CSRF 비활성화
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(
@@ -71,7 +74,7 @@ public class SecurityConfig {
         // CORS 설정을 수동으로 추가
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .addFilterBefore(
-            new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailService),
+            new JwtAuthenticationFilter(jwtUtil, customUserDetailService),
             UsernamePasswordAuthenticationFilter.class) // JWT 필터 추가
         .build();
   }

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -23,6 +24,7 @@ import com.ilta.solepli.global.util.JwtUtil;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableMethodSecurity // @PreAuthorize 사용 가능하게 함
 @EnableWebSecurity
 public class SecurityConfig {
 

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
   SAMPLE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예시: 샘플 에러가 발생했습니다."),
 
   // JWT 액세스 토큰 관련 에러
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+  TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "액세스 토큰이 없습니다."),
   TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
 

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -10,6 +10,10 @@ public enum ErrorCode {
   // 에러코드 예시: 샘플 에러
   SAMPLE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예시: 샘플 에러가 발생했습니다."),
 
+  // JWT 액세스 토큰 관련 에러
+  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
+  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
+
   // 인증 관련 에러
   INCORRECT_ACCOUNT(HttpStatus.BAD_REQUEST, "해당 계정이 존재하지 않습니다."),
   INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다."),

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -21,6 +21,9 @@ public enum ErrorCode {
   INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다."),
   INCORRECT_LOGIN_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 로그인 타입입니다."),
 
+  // 접근 권환 관련 에러
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
   // 유저 관련 에러
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보가 존재하지 않습니다."),
   USER_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 계정입니다."),

--- a/src/main/java/com/ilta/solepli/global/exception/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/ilta/solepli/global/exception/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package com.ilta.solepli.global.exception.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.ilta.solepli.global.exception.ErrorCode;
+import com.ilta.solepli.global.util.ResponseUtil;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+  @Override
+  public void handle(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AccessDeniedException accessDeniedException)
+      throws IOException {
+
+    ResponseUtil.writeError(response, ErrorCode.ACCESS_DENIED);
+  }
+}

--- a/src/main/java/com/ilta/solepli/global/util/JwtUtil.java
+++ b/src/main/java/com/ilta/solepli/global/util/JwtUtil.java
@@ -1,0 +1,56 @@
+package com.ilta.solepli.global.util;
+
+import java.security.Key;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+
+import com.ilta.solepli.global.exception.CustomException;
+import com.ilta.solepli.global.exception.ErrorCode;
+
+@Component
+public class JwtUtil {
+
+  private final Key key;
+
+  public JwtUtil(@Value("${spring.jwt.secret}") String secretKey) {
+    this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+  }
+
+  public String getLoginIdFromToken(String token) {
+    // 토큰에서 사용자 ID 추출
+    return Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .getBody()
+        .getSubject();
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+      return true;
+
+    } catch (ExpiredJwtException e) {
+      throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+    } catch (UnsupportedJwtException e) {
+      throw new CustomException(ErrorCode.INVALID_TOKEN); // 지원하지 않는 형식
+    } catch (MalformedJwtException e) {
+      throw new CustomException(ErrorCode.INVALID_TOKEN); // 잘못된 구조
+    } catch (io.jsonwebtoken.security.SignatureException e) {
+      throw new CustomException(ErrorCode.INVALID_TOKEN); // 서명 오류
+    } catch (IllegalArgumentException e) {
+      throw new CustomException(ErrorCode.INVALID_TOKEN); // 널 or 빈 문자열
+    } catch (JwtException e) {
+      throw new CustomException(ErrorCode.INVALID_TOKEN); // 기타 JWT 에러
+    }
+  }
+}

--- a/src/main/java/com/ilta/solepli/global/util/ResponseUtil.java
+++ b/src/main/java/com/ilta/solepli/global/util/ResponseUtil.java
@@ -1,0 +1,26 @@
+package com.ilta.solepli.global.util;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.ilta.solepli.global.exception.ErrorCode;
+import com.ilta.solepli.global.response.ErrorResponse;
+
+public class ResponseUtil {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  public static void writeError(HttpServletResponse response, ErrorCode errorCode)
+      throws IOException {
+    response.setStatus(errorCode.getHttpStatus().value());
+    response.setContentType("application/json;charset=UTF-8");
+
+    ErrorResponse errorResponse =
+        ErrorResponse.create()
+            .httpStatus(errorCode.getHttpStatus())
+            .message(errorCode.getMessage());
+
+    objectMapper.writeValue(response.getWriter(), errorResponse);
+  }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
#99 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
인증 관련 기능 리팩토링 완료했습니다.

### JwtAuthenticationEntryPoint
JwtAuthenticationEntryPoint는 JwtAuthenticationFilter에서 처리하지 못하는 에러 ( ex) SecurityConfig에 인증이 필요한 경로라고 적혀있는데, 인증없이 요청하는 경우)를 처리하기 위한 즉 Spring Security 내부에서 발생하는 “인증 실패” 에러를 우리가 원하는 방식으로 커스터마이징하기 위해 사용했습니다.
### JwtAccessDeniedHandler
JwtAccessDeniedHandler는 Spring Security가 발생시키는 "인가 실패(403)" 에러를 우리가 원하는 방식으로 커스터마이징하기 위해 사용했습니다.
그리고 Spring Security에서는 역할 구분에 ROLE_ 접두어를 필요로 한다고 합니다.
추후에 컨트롤러 메소드 위에 `@PreAuthorize("hasRole('ADMIN')")` 등을 붙여 사용자 인가를 진행할 수 있습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링

