### PR TITLE
Fix: HttpMessageNotReadableException 처리 코드 추가 (#120)

### DIFF
--- a/src/main/java/com/ilta/solepli/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ilta/solepli/global/exception/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.time.format.DateTimeParseException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -54,6 +55,20 @@ public class GlobalExceptionHandler {
 
     ErrorResponse response =
         ErrorResponse.create().message(ex.getMessage()).httpStatus(HttpStatus.BAD_REQUEST);
+
+    return ResponseEntity.badRequest().body(response);
+  }
+
+  @ExceptionHandler(value = {HttpMessageNotReadableException.class})
+  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException ex) {
+
+    log.error("HttpMessageNotReadableException : {}", ex.getMessage());
+
+    String message = "요청 형식이 잘못되었습니다. (JSON 파싱 오류)";
+
+    ErrorResponse response =
+        ErrorResponse.create().message(message).httpStatus(HttpStatus.BAD_REQUEST);
 
     return ResponseEntity.badRequest().body(response);
   }


### PR DESCRIPTION
## #️⃣ Issue Number
#120
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
`GlobalExceptionHandler`에 `HttpMessageNotReadableException` 처리하는 코드 추가했습니다.

아래 사진은 type의 값을 enum 값으로 변환 중에 발생한 에러를 잡는은 결과입니다.
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/09f20c86-c634-4504-bbab-d35c092bf93b" />

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정
- [x] 코드 리팩토링

