### PR TITLE
Fix: 쏠마크 저장 리스트 조회시 장소 개수 불일치 수정 (#128)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -1,6 +1,7 @@
 package com.ilta.solepli.domain.solmark.place.service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,14 +73,29 @@ public class SolmarkPlaceService {
     List<SolmarkPlaceCollection> solmarkPlaceCollections =
         solmarkPlaceCollectionRepository.findByUser(user);
 
+    // 각 저장 리스트 ID 추출
+    List<Long> collecionIds =
+        solmarkPlaceCollections.stream().map(SolmarkPlaceCollection::getId).toList();
+
+    // 컬렉션별 장소 개수(soft delete 제외) 집계 쿼리 실행 및 결과 Map으로 변환
+    List<CollectionCountDto> collectionCountDtos =
+        solmarkPlaceRepository.countByCollectionIds(collecionIds);
+    Map<Long, Long> placeCountMap =
+        collectionCountDtos.stream()
+            .collect(Collectors.toMap(CollectionCountDto::collectionId, CollectionCountDto::count));
+
     return solmarkPlaceCollections.stream()
         // CollectionResponse DTO 매핑
-        .map(this::mapToCollectionResponse)
+        .map(
+            spc -> {
+              // 장소 개수는 placeCountMap에서 꺼내고, 없으면 0
+              long count = placeCountMap.getOrDefault(spc.getId(), 0L);
+              return mapToCollectionResponse(spc, (int) count);
+            })
         .toList();
   }
 
-  private CollectionResponse mapToCollectionResponse(SolmarkPlaceCollection spc) {
-    int placeCount = spc.getSolmarkPlaces().size();
+  private CollectionResponse mapToCollectionResponse(SolmarkPlaceCollection spc, int placeCount) {
 
     return CollectionResponse.builder()
         .collectionId(spc.getId())


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#128 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- countByCollectionIds를 사용해서 쏠마크 저장 리스트별 삭제(soft-delete)되지 않은 장소의 개수만 조회후 Map으로 변환하여 장소 개수를 추출할수있도록 하였습니다.
```java
  @Query(
      """
    SELECT new com.ilta.solepli.domain.solmark.place.dto.CollectionCountDto(sp.solmarkPlaceCollection.id, COUNT(*))
    FROM SolmarkPlace sp
    WHERE sp.solmarkPlaceCollection.id IN :collectionIds
    AND sp.deletedAt IS NULL
    GROUP BY sp.solmarkPlaceCollection.id
""")
  List<CollectionCountDto> countByCollectionIds(List<Long> collectionIds);
``` 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
