### PR TITLE
Fix: Prometheus 메트릭 엔드포인트 인증 없이 접근 허용 (#138)

### DIFF
--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -41,6 +41,9 @@ public class SecurityConfig {
   @Value("${frontend.origin}")
   private String frontEndOrigin;
 
+  @Value("${management.server.base-path}")
+  private String actuatorBasePath;
+
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     return http.csrf(csrf -> csrf.disable()) // JWT 기반 인증이라 CSRF 비활성화
@@ -82,7 +85,11 @@ public class SecurityConfig {
                         "/api/profile/validate/nickname")
                     .permitAll()
                     .requestMatchers(
-                        HttpMethod.GET, "/api/sollect/*", "/api/notice", "/api/notice/*")
+                        HttpMethod.GET,
+                        "/api/sollect/*",
+                        "/api/notice",
+                        "/api/notice/*",
+                        actuatorBasePath + "/actuator/prometheus")
                     .permitAll()
                     .anyRequest()
                     .authenticated() // 그 외 요청은 인증 필요


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#138 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Prometheus 스크랩용 Actuator 엔드포인트에 인증 없이 접근이 안되도록 되어있어서 인증 없이 접근할 수 있도록 SecurityConfig에 permitAll() 설정을 추가하여 해결하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
