### PR TITLE
Fix: EndpointRequest.to(prometheus)로 actuator prometheus 엔드포인트 인증 없이 허용 (#140)

### DIFF
--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.ilta.solepli.global.config;
 import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -40,9 +41,6 @@ public class SecurityConfig {
 
   @Value("${frontend.origin}")
   private String frontEndOrigin;
-
-  @Value("${management.server.base-path}")
-  private String actuatorBasePath;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -85,11 +83,9 @@ public class SecurityConfig {
                         "/api/profile/validate/nickname")
                     .permitAll()
                     .requestMatchers(
-                        HttpMethod.GET,
-                        "/api/sollect/*",
-                        "/api/notice",
-                        "/api/notice/*",
-                        actuatorBasePath + "/actuator/prometheus")
+                        HttpMethod.GET, "/api/sollect/*", "/api/notice", "/api/notice/*")
+                    .permitAll()
+                    .requestMatchers(EndpointRequest.to("prometheus"))
                     .permitAll()
                     .anyRequest()
                     .authenticated() // 그 외 요청은 인증 필요


### PR DESCRIPTION
## #️⃣ Issue Number


<!--- ex) #이슈번호, #이슈번호 -->
#140 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- EndpointRequest.to("prometheus")를 활용하여, prometheus actuator endpoint에 인증 없이 접근할 수 있도록 수정합니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
