### PR TITLE
Fix: log-back 및 spring docker에 UTF-8 인코딩 설정 추가 (#142)

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -21,6 +21,7 @@
 
         <!-- 로그 출력 형식 지정 -->
         <encoder>
+            <charset>UTF-8</charset>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
 
@@ -47,6 +48,7 @@
 
         <!-- 로그 출력 형식 지정 -->
         <encoder>
+            <charset>UTF-8</charset>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
 
@@ -73,6 +75,7 @@
 
         <!-- 로그 출력 형식 지정 -->
         <encoder>
+            <charset>UTF-8</charset>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
 
@@ -86,6 +89,7 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
+            <charset>UTF-8</charset>
             <pattern>
                 %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%-5level){WARN=yellow, ERROR=red, INFO=cyan, DEBUG=blue, TRACE=green} %clr(${PID:- }){magenta} %clr([%thread]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx
             </pattern>


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#142 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- EC2 환경에서 logback을 통해 출력되는 한글 로그가 깨진 상태로 로그가 저장되고 있었습니다.
- logback 설정 파일과 도커 컴포즈 파일에 UTF-8 관련 설정을 반영했습니다.
- 다음과 같이 docker-compose.blue.yml, docker-compose.green.yml 모두 JAVA_TOOL_OPTIONS 환경변수에 -Dfile.encoding=UTF-8 설정을 추가하여 UTF-8 인코딩을 강제 적용했습니다.
![image](https://github.com/user-attachments/assets/144aad63-303b-40e2-aec2-b11440eb6098)

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
