### PR TITLE
Feat: 쏠마크 장소 리스트 조회시 응답 필드값 변경 및 추가 (#149)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmark/place/dto/response/SolmarkPlaceDto.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/dto/response/SolmarkPlaceDto.java
@@ -6,9 +6,13 @@ import lombok.Builder;
 
 @Builder
 public record SolmarkPlaceDto(
-    Long PlaceId,
+    Long id,
     String name,
     String detailedCategory,
     Integer recommendationPercent,
     List<String> tags,
-    Double rating) {}
+    Double rating,
+    String category,
+    String address,
+    Double latitude,
+    Double longitude) {}

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/repository/SolmarkPlaceRepository.java
@@ -34,6 +34,8 @@ public interface SolmarkPlaceRepository extends JpaRepository<SolmarkPlace, Long
     FROM SolmarkPlace sp
     JOIN sp.solmarkPlaceCollection spc
     JOIN FETCH sp.place p
+    JOIN FETCH p.placeCategories pc
+    JOIN FETCH pc.category c
     WHERE spc.deletedAt IS NULL
     AND sp.deletedAt IS NULL
     AND spc.user = :user

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -129,14 +129,22 @@ public class SolmarkPlaceService {
     Integer recommendationPercent = placeRepository.getRecommendationPercent(placeId);
     List<String> tags = placeRepository.getTopTagsForPlace(placeId, TAG_LIMIT);
     Double rating = PlaceUtil.truncateTo2Decimals(sp.getPlace().getRating());
+    String category = sp.getPlace().getPlaceCategories().get(0).getCategory().getName();
+    String address = sp.getPlace().getAddress();
+    Double latitude = sp.getPlace().getLatitude();
+    Double longitude = sp.getPlace().getLongitude();
 
     return SolmarkPlaceDto.builder()
-        .PlaceId(placeId)
+        .id(placeId)
         .name(name)
         .detailedCategory(detailedCategory)
         .recommendationPercent(recommendationPercent)
         .tags(tags)
         .rating(rating)
+        .category(category)
+        .address(address)
+        .latitude(latitude)
+        .longitude(longitude)
         .build();
   }
 


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#149 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠마크 장소 리스트 조회시 응답 필드값을 변경 및 추가하였습니다.
- placeId -> id 변경, category, address, latitude, longtitude 추가

- 쏠마크 장소 리스트 조회후 각 쏠마크 장소를 반복문을 돌면서 category를 조회하기때문에 N + 1 문제를 방지하고자 
    JOIN FETCH p.placeCategories pc
    JOIN FETCH pc.category c
    를 추가하였습니다.
```java
  @Query(
      """
    SELECT sp
    FROM SolmarkPlace sp
    JOIN sp.solmarkPlaceCollection spc
    JOIN FETCH sp.place p
    JOIN FETCH p.placeCategories pc
    JOIN FETCH pc.category c
    WHERE spc.deletedAt IS NULL
    AND sp.deletedAt IS NULL
    AND spc.user = :user
    AND spc.id = :collectionId
""")
  List<SolmarkPlace> findByUserAndCollectionId(User user, Long collectionId);
``` 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
