### PR TITLE
Fix: 관리자 회원가입시 닉네임 중복 문제 및 쏠맵 장소의 이미지 없는 리뷰가 조회되지 않는 문제 해결 (#151)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/review/repository/ReviewRepository.java
@@ -22,7 +22,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
                       SELECT r
                       FROM Review r
                       JOIN FETCH r.user u
-                      JOIN FETCH r.reviewImages ri
+                      LEFT JOIN FETCH r.reviewImages ri
                       WHERE r.place.id = :placeId
                       ORDER BY r.createdAt DESC
                   """)

--- a/src/main/java/com/ilta/solepli/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.ilta.solepli.domain.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.ilta.solepli.domain.user.entity.User;
 
@@ -13,5 +14,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Boolean existsByNickname(String nickname);
 
+  @Query(
+      value =
+          "SELECT * "
+              + "FROM users "
+              + "WHERE nickname LIKE CONCAT(:prefix, '%') "
+              + "ORDER BY CAST(SUBSTRING(nickname, CHAR_LENGTH(:prefix) + 1) AS UNSIGNED) DESC "
+              + "LIMIT 1",
+      nativeQuery = true)
   Optional<User> findTopByNicknameStartingWithOrderByNicknameDesc(String prefix);
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
#151 

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠맵의 장소 상세정보 조회시 이미지가 없는 리뷰를 조회가 되지 않는 문제를 Left Join으로 변경하여 해결하였습니다.
```java
  JOIN FETCH r.user u
  LEFT JOIN FETCH r.reviewImages ri
``` 

- 관리자 닉네임을 문자열 기준으로 정렬해 가장 큰 값을 찾다 보니, '관리자10'이 있어도 '관리자9'가 마지막으로 조회되어 닉네임 중복 오류가 발생하였습니다. 
- 닉네임의 숫자 부분을 분리해 숫자 기준으로 내림차순 정렬하도록 쿼리를 수정함으로써, 가장 큰 숫자를 가진 닉네임을 정확하게 조회할수 있도록 수정하였습니다.

```java
  @Query(
      value =
          "SELECT * "
              + "FROM users "
              + "WHERE nickname LIKE CONCAT(:prefix, '%') "
              + "ORDER BY CAST(SUBSTRING(nickname, CHAR_LENGTH(:prefix) + 1) AS UNSIGNED) DESC "
              + "LIMIT 1",
      nativeQuery = true)
``` 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
