### PR TITLE
Feat: 쏠맵 장소 프리뷰 조회시 사용자의 장소 쏠마크 판별 여부 기능 구현 (#153)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/controller/SolmapController.java
@@ -80,6 +80,7 @@ public class SolmapController {
       description = "지도 화면 내 선택된 카테고리별 장소 리스트 조회 API 입니다.")
   @GetMapping("/places")
   public ResponseEntity<SuccessResponse<PlaceSearchPreviewResponse>> getPlacesPreview(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @RequestParam Double swLat,
       @RequestParam Double swLng,
       @RequestParam Double neLat,
@@ -93,7 +94,17 @@ public class SolmapController {
 
     PlaceSearchPreviewResponse response =
         solmapService.getPlacesPreview(
-            swLat, swLng, neLat, neLng, userLat, userLng, category, cursorId, cursorDist, limit);
+            swLat,
+            swLng,
+            neLat,
+            neLng,
+            userLat,
+            userLng,
+            category,
+            cursorId,
+            cursorDist,
+            limit,
+            customUserDetails);
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
@@ -126,6 +137,7 @@ public class SolmapController {
   @Operation(summary = "지역 검색 장소 리스트 조회 API", description = "지역 검색 장소 리스트 조회 API 입니다.")
   @GetMapping("/region/{regionName}/places")
   public ResponseEntity<SuccessResponse<PlaceSearchPreviewResponse>> getPlacesByRegionPreview(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @PathVariable String regionName,
       @RequestParam Double userLat,
       @RequestParam Double userLng,
@@ -136,7 +148,7 @@ public class SolmapController {
 
     PlaceSearchPreviewResponse response =
         solmapService.getPlacesByRegionPreview(
-            regionName, userLat, userLng, category, cursorId, cursorDist, limit);
+            regionName, userLat, userLng, category, cursorId, cursorDist, limit, customUserDetails);
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
@@ -164,12 +176,13 @@ public class SolmapController {
   @Operation(summary = "연관 검색어 결과 장소 리스트 조회 API", description = "연관 검색어 결과 장소 리스트 조회 API 입니다.")
   @GetMapping("/places/search/related")
   public ResponseEntity<SuccessResponse<PlaceSearchPreviewResponse>> getPlacePreviewByRelatedSearch(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @RequestParam List<Long> ids,
       @RequestParam(required = false) Long cursorId,
       @RequestParam(required = false, defaultValue = "5") int limit) {
 
     PlaceSearchPreviewResponse response =
-        solmapService.getPlacePreviewByRelatedSearch(ids, cursorId, limit);
+        solmapService.getPlacePreviewByRelatedSearch(ids, cursorId, limit, customUserDetails);
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
@@ -177,6 +190,7 @@ public class SolmapController {
   @Operation(summary = "검색결과 없을시 주변 장소 조회 API", description = "검색결과 없을시 주변 장소 조회 API 입니다.")
   @GetMapping("/places/nearby")
   public ResponseEntity<SuccessResponse<PlaceSearchPreviewResponse>> getPlacesPreviewNearby(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @RequestParam Double userLat,
       @RequestParam Double userLng,
       @RequestParam(required = false) Long cursorId,
@@ -184,7 +198,8 @@ public class SolmapController {
       @RequestParam(required = false, defaultValue = "5") int limit) {
 
     PlaceSearchPreviewResponse response =
-        solmapService.getPlacesPreviewNearby(userLat, userLng, cursorId, cursorDist, limit);
+        solmapService.getPlacesPreviewNearby(
+            userLat, userLng, cursorId, cursorDist, limit, customUserDetails);
 
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }

--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/PlacePreviewDetail.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/PlacePreviewDetail.java
@@ -16,4 +16,5 @@ public record PlacePreviewDetail(
     Double rating,
     Boolean isOpen,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime closingTime,
+    Boolean isMarked,
     List<String> thumbnailUrls) {}

--- a/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/service/SolmapService.java
@@ -214,7 +214,8 @@ public class SolmapService {
       String category,
       Long cursorId,
       Double cursorDist,
-      int limit) {
+      int limit,
+      CustomUserDetails customUserDetails) {
 
     // 좌표, 카테고리 유효성 검증
     validViewport(swLat, swLng, neLat, neLng);
@@ -225,11 +226,16 @@ public class SolmapService {
         getPlacesByViewPort(
             swLat, swLng, neLat, neLng, userLat, userLng, category, cursorId, cursorDist, limit);
 
+    // 사용자가 쏠마크한 장소 ID Set 추출
+    User user = SecurityUtil.getUser(customUserDetails);
+    Set<Long> solmarkedPlaceIds = getSolmarkedPlaceIds(user, places);
+
     // 다음 페이지 커서 값 세팅 (limit+1번째 데이터가 존재할 경우에만)
     CursorInfo next = setNextCursor(places, userLat, userLng, limit);
 
     // PreviewDetail DTO 매핑
-    List<PlacePreviewDetail> placePreviewDetails = mapToPreviewDetails(places, limit);
+    List<PlacePreviewDetail> placePreviewDetails =
+        mapToPreviewDetails(places, limit, solmarkedPlaceIds);
 
     return PlaceSearchPreviewResponse.builder()
         .places(placePreviewDetails)
@@ -483,7 +489,8 @@ public class SolmapService {
       String category,
       Long cursorId,
       Double cursorDist,
-      int limit) {
+      int limit,
+      CustomUserDetails customUserDetails) {
 
     // 카테고리, 지역명 유효성 검증
     validCategory(category);
@@ -494,11 +501,16 @@ public class SolmapService {
         fetchPlacesByRegionAndCursor(
             userLat, userLng, regionName, category, cursorId, cursorDist, limit);
 
+    // 사용자가 쏠마크한 장소 ID Set 추출
+    User user = SecurityUtil.getUser(customUserDetails);
+    Set<Long> solmarkedPlaceIds = getSolmarkedPlaceIds(user, fetched);
+
     // 다음 페이지 커서 값 세팅 (limit+1번째 데이터가 존재할 경우에만)
     CursorInfo next = setNextCursor(fetched, userLat, userLng, limit);
 
     // 조회된 장소 중 limit개만 PlacePreviewDetail DTO 매핑
-    List<PlacePreviewDetail> placePreviewDetails = mapToPreviewDetails(fetched, limit);
+    List<PlacePreviewDetail> placePreviewDetails =
+        mapToPreviewDetails(fetched, limit, solmarkedPlaceIds);
 
     return PlaceSearchPreviewResponse.builder()
         .places(placePreviewDetails)
@@ -549,7 +561,8 @@ public class SolmapService {
     return CursorInfo.of(nextCursor, nextCursorDist);
   }
 
-  private List<PlacePreviewDetail> mapToPreviewDetails(List<Place> fetched, int limit) {
+  private List<PlacePreviewDetail> mapToPreviewDetails(
+      List<Place> fetched, int limit, Set<Long> solmarkedPlaceIds) {
 
     return fetched.stream()
         .limit(limit) // limit개만 결과로 반환
@@ -562,6 +575,7 @@ public class SolmapService {
               OpenStatus openStatus = getOpenStatus(p);
               Integer isSoloRecommendedPercent =
                   placeRepository.getRecommendationPercent(p.getId());
+              boolean isMarked = solmarkedPlaceIds.contains(p.getId());
 
               return PlacePreviewDetail.builder()
                   .id(p.getId())
@@ -572,6 +586,7 @@ public class SolmapService {
                   .rating(truncateTo2Decimals(p.getRating()))
                   .isOpen(openStatus.isOpen())
                   .closingTime(openStatus.closingTime())
+                  .isMarked(isMarked)
                   .thumbnailUrls(reviewThumbnails)
                   .build();
             })
@@ -726,7 +741,7 @@ public class SolmapService {
 
   @Transactional(readOnly = true)
   public PlaceSearchPreviewResponse getPlacePreviewByRelatedSearch(
-      List<Long> ids, Long cursorId, int limit) {
+      List<Long> ids, Long cursorId, int limit, CustomUserDetails customUserDetails) {
 
     // 커서 기준으로 시작 인덱스 계산 (없으면 0)
     int startIdx = 0;
@@ -746,13 +761,18 @@ public class SolmapService {
     // placeId로 Place 조회 (순서 보장 X)
     List<Place> places = placeRepository.findByPlace_IdIn(placeIds);
 
+    // 사용자가 쏠마크한 장소 ID Set 추출
+    User user = SecurityUtil.getUser(customUserDetails);
+    Set<Long> solmarkedPlaceIds = getSolmarkedPlaceIds(user, places);
+
     // 조회 결과를 placeIds 순서대로 정렬
     Map<Long, Place> placeMap =
         places.stream().collect(Collectors.toMap(Place::getId, Function.identity()));
     List<Place> orderedPlaces = placeIds.stream().map(placeMap::get).toList();
 
     // PlacePreviewDetail DTO로 매핑
-    List<PlacePreviewDetail> placePreviewDetails = mapToPreviewDetails(orderedPlaces, limit);
+    List<PlacePreviewDetail> placePreviewDetails =
+        mapToPreviewDetails(orderedPlaces, limit, solmarkedPlaceIds);
 
     // 더 불러올 데이터가 있으면 다음 커서 id, 없으면 null
     Long nextCursor = (endIdx < ids.size()) ? ids.get(endIdx - 1) : null;
@@ -765,13 +785,24 @@ public class SolmapService {
 
   @Transactional(readOnly = true)
   public PlaceSearchPreviewResponse getPlacesPreviewNearby(
-      Double userLat, Double userLng, Long cursorId, Double cursorDist, int limit) {
+      Double userLat,
+      Double userLng,
+      Long cursorId,
+      Double cursorDist,
+      int limit,
+      CustomUserDetails customUserDetails) {
     // 반경 km 이내의 장소 조회
     List<Place> places = getPlacesNearby(userLat, userLng, cursorId, cursorDist, limit);
+
+    // 사용자가 쏠마크한 장소 ID Set 추출
+    User user = SecurityUtil.getUser(customUserDetails);
+    Set<Long> solmarkedPlaceIds = getSolmarkedPlaceIds(user, places);
+
     // 커서 정보 세팅
     CursorInfo next = setNextCursor(places, userLat, userLng, limit);
     // PlacePreviewDetail DTO 매핑
-    List<PlacePreviewDetail> placePreviewDetails = mapToPreviewDetails(places, limit);
+    List<PlacePreviewDetail> placePreviewDetails =
+        mapToPreviewDetails(places, limit, solmarkedPlaceIds);
 
     return PlaceSearchPreviewResponse.builder()
         .places(placePreviewDetails)


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#153 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 쏠맵의 장소 프리뷰 조회시 사용자의 장소 쏠마크 판별 여부 기능을 추가하였습니다.
- 쏠마크 판별 여부를 추가한 API는 다음과 같습니다.
  - 지도 화면 내 선택된 카테고리별 장소 리스트 조회 API
  - 지역 검색 장소 리스트 조회 API
  - 연관 검색어 결과 장소 리스트 조회 API
  - 검색 결과 없을시 주변 장소 조회 API
- 각 API 컨트롤러에 @Authentication을 사용하여 사용자 정보를 가져오고 다음과 같이 사용자가 쏠마크한 장소 ID Set 추출하여 mapToPreviewDetails 메서드에서 각 Place마다 쏠마크한 장소인지 판별하도록하였습니다.
```java
    // 사용자가 쏠마크한 장소 ID Set 추출
    User user = SecurityUtil.getUser(customUserDetails);
    Set<Long> solmarkedPlaceIds = getSolmarkedPlaceIds(user, places);

  private List<PlacePreviewDetail> mapToPreviewDetails(
      List<Place> fetched, int limit, Set<Long> solmarkedPlaceIds) {
      // ...
     boolean isMarked = solmarkedPlaceIds.contains(p.getId());
      
``` 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
