### PR TITLE
Fix: 쏠마크 - 장소 삭제 방식 수정 및 연관검색어 km 소수점 변경 (#165)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solmap/dto/Distance.java
+++ b/src/main/java/com/ilta/solepli/domain/solmap/dto/Distance.java
@@ -6,7 +6,7 @@ public record Distance(Number value, String unit) {
       return new Distance(Math.round(meter), "m");
     } else {
       double km = meter / 1000.0;
-      double roundedKm = Math.round(km * 100.0) / 100.0;
+      double roundedKm = Math.round(km * 10.0) / 10.0;
       return new Distance(roundedKm, "km");
     }
   }

--- a/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/solmark/place/service/SolmarkPlaceService.java
@@ -6,6 +6,8 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,6 +40,8 @@ public class SolmarkPlaceService {
   private static final int MAX_PLACES_PER_COLLECTION = 100;
   private static final int MAX_COLLECTIONS_PER_USER = 50;
   private static final int TAG_LIMIT = 3;
+
+  @PersistenceContext private EntityManager entityManager;
 
   @Transactional
   public void createCollection(
@@ -225,9 +229,7 @@ public class SolmarkPlaceService {
 
     removeCollections.forEach(
         c -> {
-          c.getSolmarkPlaces().stream()
-              .filter(sp -> sp.getPlace().equals(place) && sp.getDeletedAt() == null)
-              .forEach(solmarkPlaceRepository::delete);
+          c.getSolmarkPlaces().removeIf(sp -> sp.getPlace().equals(place));
         });
   }
 


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#165 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 기존의 쏠마크 - 장소 삭제 방식이 solmarkPlaceRepository.delete()를 사용하여 엔티티를 삭제하는 방식이었는데 JPA의 orphanRemoval 특성상 부모 컬렉션에서 자식 엔티티를 제거해야 delete 쿼리가 정상적으로 발생하기때문에 이전 방식에는 delete 쿼리문에 발생하지 않았습니다. 그래서 SolmarkPlaceCollection의 컬렉션에서 removeIf로 자식 엔티티를 제거하는 방식으로 수정하여 데이터가 삭제되도록 변경하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
- [X] 코드 리팩토링
