### PR TITLE
Feat: Refresh Token 도입 (#173)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -57,5 +58,14 @@ public class AuthController {
 
     LoginResponse loginResponse = authService.socialLogin(code, loginType, response);
     return ResponseEntity.ok().body(SuccessResponse.successWithData(loginResponse));
+  }
+
+  @Operation(
+      summary = "Access Token 재발급 API",
+      description = "쿠키에 저장된 Refresh Token을 통해 Access Token을 재발급합니다.")
+  @PostMapping("/reissue-token")
+  public ResponseEntity<SuccessResponse<LoginResponse>> refreshToken(HttpServletRequest request) {
+    LoginResponse response = authService.reissueAccessToken(request);
+    return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/controller/AuthController.java
@@ -68,4 +68,12 @@ public class AuthController {
     LoginResponse response = authService.reissueAccessToken(request);
     return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
   }
+
+  @Operation(summary = "로그아웃 API", description = "Refresh Token을 만료시키고 Redis에서도 제거합니다.")
+  @PostMapping("/logout")
+  public ResponseEntity<SuccessResponse<Void>> logout(
+      HttpServletRequest request, HttpServletResponse response) {
+    authService.logout(request, response);
+    return ResponseEntity.ok().body(SuccessResponse.successWithNoData("로그아웃 성공"));
+  }
 }

--- a/src/main/java/com/ilta/solepli/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -43,18 +44,18 @@ public class AuthController {
       description = "(관리자) 아이디와 비밀번호로 로그인합니다. 로그인에 사용할 아이디와 비밀번호를 입력해주세요.")
   @PostMapping("/login")
   public ResponseEntity<SuccessResponse<LoginResponse>> login(
-      @Valid @RequestBody BasicLoginRequest basicLoginRequest) {
+      @Valid @RequestBody BasicLoginRequest basicLoginRequest, HttpServletResponse response) {
 
-    LoginResponse loginResponse = authService.login(basicLoginRequest);
+    LoginResponse loginResponse = authService.login(basicLoginRequest, response);
     return ResponseEntity.ok().body(SuccessResponse.successWithData(loginResponse));
   }
 
   @Operation(summary = "소셜 로그인 API", description = "소셜 로그인을 진행합니다. (카카오, 네이버, 구글) 인가코드를 넣어주세요.")
   @GetMapping("/login/{loginType}")
   public ResponseEntity<SuccessResponse<LoginResponse>> login(
-      @PathVariable String loginType, @RequestParam String code) {
+      @PathVariable String loginType, @RequestParam String code, HttpServletResponse response) {
 
-    LoginResponse loginResponse = authService.socialLogin(code, loginType);
+    LoginResponse loginResponse = authService.socialLogin(code, loginType, response);
     return ResponseEntity.ok().body(SuccessResponse.successWithData(loginResponse));
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/filter/JwtAuthenticationFilter.java
@@ -34,8 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       String token = resolveToken(request);
 
       if (token != null) {
-        jwtUtil.validateToken(token);
-        String loginId = jwtUtil.getLoginIdFromToken(token);
+        jwtUtil.validateAccessToken(token);
+        String loginId = jwtUtil.extractLoginId(token);
         UserDetails userDetails = customUserDetailService.loadUserByUsername(loginId);
 
         UsernamePasswordAuthenticationToken authToken =

--- a/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
@@ -134,18 +134,11 @@ public class AuthService {
     return LoginResponse.from(user.getId(), accessToken, user.getRole());
   }
 
-  private void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
-    String cookie =
-        String.format(
-            "refreshToken=%s; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=%d",
-            refreshToken, refreshTokenExpiration / 1000);
-    response.addHeader("Set-Cookie", cookie);
-  }
-
+  @Transactional
   public LoginResponse reissueAccessToken(HttpServletRequest request) {
     String refreshToken = extractTokenFromCookie(request);
     if (refreshToken == null) {
-      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+      throw new CustomException(ErrorCode.REFRESH_TOKEN_MISSING);
     }
 
     if (!jwtUtil.validateRefreshToken(refreshToken)) {
@@ -156,7 +149,7 @@ public class AuthService {
 
     String stored = redisTemplate.opsForValue().get("refresh:" + loginId);
     if (stored == null || !stored.equals(refreshToken)) {
-      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+      throw new CustomException(ErrorCode.REFRESH_TOKEN_MISSING);
     }
 
     User user =
@@ -187,6 +180,14 @@ public class AuthService {
 
     // 쿠키 만료
     expireRefreshTokenCookie(response);
+  }
+
+  private void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
+    String cookie =
+        String.format(
+            "refreshToken=%s; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=%d",
+            refreshToken, refreshTokenExpiration / 1000);
+    response.addHeader("Set-Cookie", cookie);
   }
 
   private String extractTokenFromCookie(HttpServletRequest request) {

--- a/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
@@ -8,6 +8,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +26,7 @@ import com.ilta.solepli.domain.user.repository.UserRepository;
 import com.ilta.solepli.domain.user.service.UserService;
 import com.ilta.solepli.global.exception.CustomException;
 import com.ilta.solepli.global.exception.ErrorCode;
+import com.ilta.solepli.global.util.JwtUtil;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +39,7 @@ public class AuthService {
   private final JwtTokenProvider jwtTokenProvider;
   private final SolmarkPlaceCollectionRepository solmarkPlaceCollectionRepository;
   private final RedisTemplate<String, String> redisTemplate;
+  private final JwtUtil jwtUtil;
 
   @Value("${DEFAULT_PROFILE_URL}")
   private String defaultImageUrl;
@@ -136,5 +140,42 @@ public class AuthService {
             "refreshToken=%s; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=%d",
             refreshToken, refreshTokenExpiration / 1000);
     response.addHeader("Set-Cookie", cookie);
+  }
+
+  public LoginResponse reissueAccessToken(HttpServletRequest request) {
+    String refreshToken = extractTokenFromCookie(request);
+    if (refreshToken == null) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    if (!jwtUtil.validateRefreshToken(refreshToken)) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    String loginId = jwtUtil.extractLoginId(refreshToken);
+
+    String stored = redisTemplate.opsForValue().get("refresh:" + loginId);
+    if (stored == null || !stored.equals(refreshToken)) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    User user =
+        userRepository
+            .findByLoginId(loginId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    String newAccessToken = jwtTokenProvider.generateAccessToken(user);
+
+    return LoginResponse.from(user.getId(), newAccessToken, user.getRole());
+  }
+
+  private String extractTokenFromCookie(HttpServletRequest request) {
+    if (request.getCookies() == null) return null;
+    for (Cookie cookie : request.getCookies()) {
+      if ("refreshToken".equals(cookie.getName())) {
+        return cookie.getValue();
+      }
+    }
+    return null;
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
@@ -147,7 +147,7 @@ public class AuthService {
 
     String loginId = jwtUtil.extractLoginId(refreshToken);
 
-    String stored = redisTemplate.opsForValue().get("refresh:" + loginId);
+    String stored = redisTemplate.opsForValue().get(REFRESH_PREFIX + loginId);
     if (stored == null || !stored.equals(refreshToken)) {
       throw new CustomException(ErrorCode.REFRESH_TOKEN_MISSING);
     }

--- a/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
@@ -1,10 +1,14 @@
 package com.ilta.solepli.domain.auth.service;
 
+import java.time.Duration;
+
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 import com.ilta.solepli.domain.auth.dto.request.BasicLoginRequest;
@@ -31,9 +35,15 @@ public class AuthService {
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final SolmarkPlaceCollectionRepository solmarkPlaceCollectionRepository;
+  private final RedisTemplate<String, String> redisTemplate;
 
   @Value("${DEFAULT_PROFILE_URL}")
   private String defaultImageUrl;
+
+  @Value("${spring.jwt.refresh.token.expiration}")
+  private long refreshTokenExpiration;
+
+  private static final String REFRESH_PREFIX = "refresh:";
 
   @Transactional
   public void signup(BasicLoginRequest request) {
@@ -61,7 +71,7 @@ public class AuthService {
   }
 
   @Transactional(readOnly = true)
-  public LoginResponse login(BasicLoginRequest request) {
+  public LoginResponse login(BasicLoginRequest request, HttpServletResponse response) {
     User user =
         userRepository
             .findByLoginId(request.loginId())
@@ -71,13 +81,25 @@ public class AuthService {
       throw new CustomException(ErrorCode.INCORRECT_ACCOUNT);
     }
 
-    String accessToken = jwtTokenProvider.generateToken(user);
+    String accessToken = jwtTokenProvider.generateAccessToken(user);
+    String refreshToken = jwtTokenProvider.generateRefreshToken(user);
+
+    // Redis에 Refresh Token 저장
+    redisTemplate
+        .opsForValue()
+        .set(
+            REFRESH_PREFIX + user.getLoginId(),
+            refreshToken,
+            Duration.ofMillis(refreshTokenExpiration));
+
+    // 쿠키로 Refresh Token 전달
+    addRefreshTokenToCookie(response, refreshToken);
 
     return LoginResponse.from(user.getId(), accessToken, user.getRole());
   }
 
   @Transactional
-  public LoginResponse socialLogin(String code, String input) {
+  public LoginResponse socialLogin(String code, String input, HttpServletResponse response) {
     LoginType loginType;
     try {
       loginType = LoginType.valueOf(input);
@@ -89,10 +111,30 @@ public class AuthService {
 
     String loginId = oauthService.getLoginId(oauthService.getAccessToken(code));
 
-    User findUser = userService.findOrSignUpUser(loginId, loginType);
+    User user = userService.findOrSignUpUser(loginId, loginType);
 
-    String accessToken = jwtTokenProvider.generateToken(findUser);
+    String accessToken = jwtTokenProvider.generateAccessToken(user);
+    String refreshToken = jwtTokenProvider.generateRefreshToken(user);
 
-    return LoginResponse.from(findUser.getId(), accessToken, findUser.getRole());
+    // Redis에 Refresh Token 저장
+    redisTemplate
+        .opsForValue()
+        .set(
+            REFRESH_PREFIX + user.getLoginId(),
+            refreshToken,
+            Duration.ofMillis(refreshTokenExpiration));
+
+    // 쿠키로 Refresh Token 전달
+    addRefreshTokenToCookie(response, refreshToken);
+
+    return LoginResponse.from(user.getId(), accessToken, user.getRole());
+  }
+
+  private void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
+    String cookie =
+        String.format(
+            "refreshToken=%s; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=%d",
+            refreshToken, refreshTokenExpiration / 1000);
+    response.addHeader("Set-Cookie", cookie);
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
@@ -169,6 +169,26 @@ public class AuthService {
     return LoginResponse.from(user.getId(), newAccessToken, user.getRole());
   }
 
+  @Transactional
+  public void logout(HttpServletRequest request, HttpServletResponse response) {
+    String refreshToken = extractTokenFromCookie(request);
+    if (refreshToken == null) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    if (!jwtUtil.validateRefreshToken(refreshToken)) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    String loginId = jwtUtil.extractLoginId(refreshToken);
+
+    // Redis에서 refresh 토큰 삭제
+    redisTemplate.delete(REFRESH_PREFIX + loginId);
+
+    // 쿠키 만료
+    expireRefreshTokenCookie(response);
+  }
+
   private String extractTokenFromCookie(HttpServletRequest request) {
     if (request.getCookies() == null) return null;
     for (Cookie cookie : request.getCookies()) {
@@ -177,5 +197,11 @@ public class AuthService {
       }
     }
     return null;
+  }
+
+  private void expireRefreshTokenCookie(HttpServletResponse response) {
+    String expiredCookie =
+        String.format("refreshToken=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0");
+    response.addHeader("Set-Cookie", expiredCookie);
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/AuthService.java
@@ -165,12 +165,17 @@ public class AuthService {
   @Transactional
   public void logout(HttpServletRequest request, HttpServletResponse response) {
     String refreshToken = extractTokenFromCookie(request);
+
+    // refreshToken이 없으면 유효하지 않은 상태이므로 쿠키만 만료시키고 종료
     if (refreshToken == null) {
-      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+      expireRefreshTokenCookie(response);
+      return;
     }
 
+    // 토큰 유효성 검증 실패 시에도 쿠키는 만료시키고 종료
     if (!jwtUtil.validateRefreshToken(refreshToken)) {
-      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+      expireRefreshTokenCookie(response);
+      return;
     }
 
     String loginId = jwtUtil.extractLoginId(refreshToken);

--- a/src/main/java/com/ilta/solepli/domain/auth/service/JwtTokenProvider.java
+++ b/src/main/java/com/ilta/solepli/domain/auth/service/JwtTokenProvider.java
@@ -16,23 +16,40 @@ import com.ilta.solepli.domain.user.entity.User;
 public class JwtTokenProvider {
 
   private final Key key;
-  private final long expiration;
+  private final long accessTokenExpiration;
+  private final long refreshTokenExpiration;
 
   public JwtTokenProvider(
       @Value("${spring.jwt.secret}") String secretKey,
-      @Value("${spring.jwt.access.token.expiration}") long expiration) {
+      @Value("${spring.jwt.access.token.expiration}") long accessTokenExpiration,
+      @Value("${spring.jwt.refresh.token.expiration}") long refreshTokenExpiration) {
     this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
-    this.expiration = expiration;
+    this.accessTokenExpiration = accessTokenExpiration;
+    this.refreshTokenExpiration = refreshTokenExpiration;
   }
 
-  public String generateToken(User user) {
+  /** Access Token 생성 (사용자 인증용, 짧은 유효기간) */
+  public String generateAccessToken(User user) {
     // 토큰 생성 (loginId + role 포함)
     Date now = new Date();
-    Date expiry = new Date(now.getTime() + expiration);
+    Date expiry = new Date(now.getTime() + accessTokenExpiration);
 
     return Jwts.builder()
         .setSubject(user.getLoginId())
         .claim("role", user.getRole().name())
+        .setIssuedAt(now)
+        .setExpiration(expiry)
+        .signWith(key, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  /** Refresh Token 생성 (Access Token 재발급용, claim 없음) */
+  public String generateRefreshToken(User user) {
+    Date now = new Date();
+    Date expiry = new Date(now.getTime() + refreshTokenExpiration);
+
+    return Jwts.builder()
+        .setSubject(user.getLoginId())
         .setIssuedAt(now)
         .setExpiration(expiry)
         .signWith(key, SignatureAlgorithm.HS256)

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -116,7 +116,8 @@ public class SecurityConfig {
     configuration.setAllowedMethods(
         Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(
-        Arrays.asList("X-Requested-With", "Content-Type", "Authorization", "X-XSRF-token"));
+        Arrays.asList(
+            "X-Requested-With", "Content-Type", "Authorization", "X-XSRF-token", "Set-Cookie"));
     configuration.setAllowCredentials(true);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SecurityConfig.java
@@ -60,10 +60,7 @@ public class SecurityConfig {
                         "/api-docs",
                         "/api-docs/**",
                         "/v3/api-docs/**",
-                        "/health/**",
-                        "/kakao/callback",
-                        "/naver/callback",
-                        "/google/callback")
+                        "/health/**")
                     .permitAll()
                     .requestMatchers(
                         "/api/auth/**",

--- a/src/main/java/com/ilta/solepli/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ilta/solepli/global/config/SwaggerConfig.java
@@ -20,6 +20,9 @@ public class SwaggerConfig {
   @Value("${server.url}")
   private String serverUrl;
 
+  @Value("${SWAGGER_URL}")
+  private String swaggerUrl;
+
   @Bean
   public OpenAPI openAPI() {
     String jwt = "JWT";
@@ -35,8 +38,11 @@ public class SwaggerConfig {
                     .bearerFormat("JWT"));
 
     ArrayList<Server> servers = new ArrayList<>();
-    servers.add(new Server().url("https://" + serverUrl).description("Solepli Server"));
-    servers.add(new Server().url("http://localhost:8080").description("Local Server"));
+    if (swaggerUrl.contains("localhost")) {
+      servers.add(new Server().url(swaggerUrl).description("Local Server"));
+    } else {
+      servers.add(new Server().url(swaggerUrl).description("Solepli Server"));
+    }
 
     return new OpenAPI()
         .components(new Components())

--- a/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
+++ b/src/main/java/com/ilta/solepli/global/exception/ErrorCode.java
@@ -10,11 +10,17 @@ public enum ErrorCode {
   // 에러코드 예시: 샘플 에러
   SAMPLE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예시: 샘플 에러가 발생했습니다."),
 
-  // JWT 액세스 토큰 관련 에러
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
-  TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "액세스 토큰이 없습니다."),
-  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
-  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
+
+  // JWT 액세스 토큰 관련 에러
+  ACCESS_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "액세스 토큰이 없습니다."),
+  ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
+  INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
+
+  // JWT 리프레시 토큰 관련 에러
+  REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
+  INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+  REFRESH_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 존재하지 않습니다."),
 
   // 인증 관련 에러
   INCORRECT_ACCOUNT(HttpStatus.BAD_REQUEST, "해당 계정이 존재하지 않습니다."),

--- a/src/main/java/com/ilta/solepli/global/util/JwtUtil.java
+++ b/src/main/java/com/ilta/solepli/global/util/JwtUtil.java
@@ -24,7 +24,7 @@ public class JwtUtil {
     this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
   }
 
-  public String getLoginIdFromToken(String token) {
+  public String extractLoginId(String token) {
     // 토큰에서 사용자 ID 추출
     return Jwts.parserBuilder()
         .setSigningKey(key)
@@ -34,23 +34,42 @@ public class JwtUtil {
         .getSubject();
   }
 
-  public boolean validateToken(String token) {
+  public boolean validateAccessToken(String token) {
     try {
       Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
       return true;
 
     } catch (ExpiredJwtException e) {
-      throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+      throw new CustomException(ErrorCode.ACCESS_TOKEN_EXPIRED);
     } catch (UnsupportedJwtException e) {
-      throw new CustomException(ErrorCode.INVALID_TOKEN); // 지원하지 않는 형식
+      throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN); // 지원하지 않는 형식
     } catch (MalformedJwtException e) {
-      throw new CustomException(ErrorCode.INVALID_TOKEN); // 잘못된 구조
+      throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN); // 잘못된 구조
     } catch (io.jsonwebtoken.security.SignatureException e) {
-      throw new CustomException(ErrorCode.INVALID_TOKEN); // 서명 오류
+      throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN); // 서명 오류
     } catch (IllegalArgumentException e) {
-      throw new CustomException(ErrorCode.INVALID_TOKEN); // 널 or 빈 문자열
+      throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN); // 널 or 빈 문자열
     } catch (JwtException e) {
-      throw new CustomException(ErrorCode.INVALID_TOKEN); // 기타 JWT 에러
+      throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN); // 기타 JWT 에러
+    }
+  }
+
+  public boolean validateRefreshToken(String token) {
+    try {
+      Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+      return true;
+    } catch (ExpiredJwtException e) {
+      throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+    } catch (UnsupportedJwtException e) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN); // 지원하지 않는 형식
+    } catch (MalformedJwtException e) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN); // 잘못된 구조
+    } catch (io.jsonwebtoken.security.SignatureException e) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN); // 서명 오류
+    } catch (IllegalArgumentException e) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN); // 널 or 빈 문자열
+    } catch (JwtException e) {
+      throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN); // 기타 JWT 에러
     }
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,7 +34,10 @@ spring:
     secret: ${JWT_SECRET}
     access:
       token:
-        expiration: ${JWT_EXPIRATION}
+        expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
+    refresh:
+      token:
+        expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}
 
   # Redis
   data:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -34,7 +34,10 @@ spring:
     secret: ${JWT_SECRET}
     access:
       token:
-        expiration: ${JWT_EXPIRATION}
+        expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
+    refresh:
+      token:
+        expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}
 
   # Redis
   data:


### PR DESCRIPTION
## #️⃣ Issue Number
#173
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
Refresh 토큰 도입 완료했습니다.
`HttpOnly + Secure 쿠키` 방식으로 Refresh Token을 응답하여 보안 강화, 재발급 요청시 프론트엔드 측에서 Refresh Token을 직접 관리할 필요가 없도록 했습니다.

자세한 내용은
https://www.notion.so/RefreshToken-236b1c30cf3b809286d1d87d1124fd03?source=copy_link 참고해주세요

그리고 로컬에서는 로컬만, 서버에서는 서버만 뜨도록 Swagger 설정 수정했습니다.

그리고 .env 파일 수정됐으니 참고해주세요!!
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

