### PR TITLE
Refactor: 장소 검색 쿼리에 주소 검색어 조건 추가 및 커서 기반 페이징 적용 (#177)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/ilta/solepli/domain/place/controller/PlaceController.java
@@ -1,7 +1,5 @@
 package com.ilta.solepli.domain.place.controller;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -32,12 +30,15 @@ public class PlaceController {
 
   @Operation(summary = "장소 검색 API", description = "장소 추가 화면에서 사용되는 검색 API입니다.")
   @GetMapping("/search")
-  public ResponseEntity<SuccessResponse<List<PlaceSearchResponse>>> searchPlaces(
+  public ResponseEntity<SuccessResponse<PlaceSearchResponse>> searchPlaces(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(defaultValue = "10") int size,
       @RequestParam(required = true) String keyword) {
 
     User user = SecurityUtil.getUser(customUserDetails);
-    List<PlaceSearchResponse> searchContents = placeService.getSearchPlaces(user, keyword);
+    PlaceSearchResponse searchContents =
+        placeService.getSearchPlaces(user, cursorId, size, keyword);
 
     return ResponseEntity.ok(SuccessResponse.successWithData(searchContents));
   }

--- a/src/main/java/com/ilta/solepli/domain/place/dto/response/PlaceSearchResponse.java
+++ b/src/main/java/com/ilta/solepli/domain/place/dto/response/PlaceSearchResponse.java
@@ -1,26 +1,37 @@
 package com.ilta.solepli.domain.place.dto.response;
 
+import java.util.List;
+
 import lombok.Builder;
 
+import com.ilta.solepli.domain.sollect.dto.response.SollectSearchResponse.CursorInfo;
+
 @Builder
-public record PlaceSearchResponse(
-    Long id,
-    String name,
-    String category,
-    String detailedCategory,
-    String address,
-    Double latitude,
-    Double longitude,
-    Boolean isMarked) {
-  public static PlaceSearchResponse from(PlaceSearchResponseDTO dto, Boolean isMarked) {
-    return new PlaceSearchResponse(
-        dto.id(),
-        dto.name(),
-        dto.category(),
-        dto.detailedCategory(),
-        dto.address(),
-        dto.latitude(),
-        dto.longitude(),
-        isMarked);
+public record PlaceSearchResponse(List<PlaceSearchContent> contents, CursorInfo cursorInfo) {
+
+  @Builder
+  public record PlaceSearchContent(
+      Long id,
+      String name,
+      String category,
+      String detailedCategory,
+      String address,
+      Double latitude,
+      Double longitude,
+      Boolean isMarked) {
+    public static PlaceSearchContent from(PlaceSearchResponseDTO dto, Boolean isMarked) {
+      return new PlaceSearchContent(
+          dto.id(),
+          dto.name(),
+          dto.category(),
+          dto.detailedCategory(),
+          dto.address(),
+          dto.latitude(),
+          dto.longitude(),
+          isMarked);
+    }
   }
+
+  @Builder
+  public record cursorInfo(Long nextCursorId, boolean hasNext) {}
 }

--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryCustom.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryCustom.java
@@ -16,7 +16,7 @@ public interface PlaceRepositoryCustom {
 
   Integer getRecommendationPercent(Long placeId);
 
-  List<PlaceSearchResponseDTO> getPlacesByKeyword(String keyword);
+  List<PlaceSearchResponseDTO> getPlacesByKeyword(Long cursorId, Integer size, String keyword);
 
   SollectPlaceAddPreviewResponse getSollectAddPreview(Long placeId);
 }

--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
@@ -2,7 +2,9 @@ package com.ilta.solepli.domain.place.repository;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -89,14 +91,28 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
   }
 
   @Override
-  public List<PlaceSearchResponseDTO> getPlacesByKeyword(String keyword) {
+  public List<PlaceSearchResponseDTO> getPlacesByKeyword(
+      Long cursorId, Integer size, String keyword) {
+
+    BooleanBuilder cond = new BooleanBuilder();
+    if (keyword != null && !keyword.isBlank()) {
+      cond.and(p.name.contains(keyword).or(p.address.contains(keyword)));
+    }
+    if (cursorId != null) {
+      cond.and(p.id.lt(cursorId));
+    }
+
     return jpaQueryFactory
         .select(p)
+        .distinct()
         .from(p)
-        .join(p.placeCategories, pc)
-        .join(pc.category, c)
-        .where(p.name.contains(keyword))
-        .limit(10)
+        .leftJoin(p.placeCategories, pc)
+        .fetchJoin()
+        .leftJoin(pc.category, c)
+        .fetchJoin()
+        .where(cond)
+        .orderBy(p.id.desc())
+        .limit(size + 1) // 커서 페이징이므로 size+1
         .fetch()
         .stream()
         .map(
@@ -110,7 +126,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                     .latitude(p.getLatitude())
                     .longitude(p.getLongitude())
                     .build())
-        .toList();
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/src/main/java/com/ilta/solepli/domain/place/service/PlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/place/service/PlaceService.java
@@ -31,6 +31,7 @@ import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.place.entity.PlaceCategory;
 import com.ilta.solepli.domain.place.entity.PlaceHour;
 import com.ilta.solepli.domain.place.repository.PlaceRepository;
+import com.ilta.solepli.domain.sollect.dto.response.SollectSearchResponse.CursorInfo;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlace;
 import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceRepository;
 import com.ilta.solepli.domain.user.entity.User;
@@ -56,17 +57,32 @@ public class PlaceService {
   private final CategoryRepository categoryRepository;
 
   @Transactional(readOnly = true)
-  public List<PlaceSearchResponse> getSearchPlaces(User user, String keyword) {
-    List<PlaceSearchResponseDTO> responseDTOList = placeRepository.getPlacesByKeyword(keyword);
-    List<Long> placeIds = responseDTOList.stream().map(dto -> dto.id()).toList();
+  public PlaceSearchResponse getSearchPlaces(
+      User user, Long cursorId, Integer size, String keyword) {
+    List<PlaceSearchResponseDTO> responseDTOList =
+        placeRepository.getPlacesByKeyword(cursorId, size, keyword);
+    System.out.println(responseDTOList.size());
+    boolean hasNext = responseDTOList.size() > size;
+    if (hasNext) responseDTOList.remove(size); // 커서 페이징이므로 초과 1개 제거
 
+    List<Long> placeIds = responseDTOList.stream().map(dto -> dto.id()).toList();
     Set<Long> solmarkedPlaceIds = getSolmarkedPlaceIds(user, placeIds);
 
-    List<PlaceSearchResponse> response = new ArrayList<>();
+    List<PlaceSearchResponse.PlaceSearchContent> contents = new ArrayList<>();
     for (PlaceSearchResponseDTO dto : responseDTOList) {
-      PlaceSearchResponse p = PlaceSearchResponse.from(dto, solmarkedPlaceIds.contains(dto.id()));
-      response.add(p);
+      PlaceSearchResponse.PlaceSearchContent p =
+          PlaceSearchResponse.PlaceSearchContent.from(dto, solmarkedPlaceIds.contains(dto.id()));
+      contents.add(p);
     }
+
+    Long nextCursorId = hasNext ? contents.get(contents.size() - 1).id() : null;
+
+    PlaceSearchResponse response =
+        PlaceSearchResponse.builder()
+            .contents(contents)
+            .cursorInfo(CursorInfo.builder().hasNext(hasNext).nextCursorId(nextCursorId).build())
+            .build();
+
     return response;
   }
 


### PR DESCRIPTION
## #️⃣ Issue Number
#177
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
장소 검색 쿼리에 주소 검색어 조건 추가 및 커서 기반 페이징 적용완료했습니다!

```
return jpaQueryFactory
        .select(p)
        .distinct()
        .from(p)
        .leftJoin(p.placeCategories, pc)
        .fetchJoin()
        .leftJoin(pc.category, c)
        .fetchJoin()
        .where(cond)
        .orderBy(p.id.desc())
        .limit(size + 1) // 커서 페이징이므로 size+1
        .fetch()
        .stream()
        .map(
            p ->
                PlaceSearchResponseDTO.builder()
                    .id(p.getId())
                    .name(p.getName())
                    .category(getMainCategory(p))
                    .detailedCategory(p.getTypes())
                    .address(p.getAddress())
                    .latitude(p.getLatitude())
                    .longitude(p.getLongitude())
                    .build())
        .collect(Collectors.toList());
```

다음과 같이 주소 검색어 조건도 추가했고, fetchJoin을 사용하여 n+1 문제도 방지했습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링