### PR TITLE
Refactor: 장소 검색시 검색어 조건에 장소의 주소도 추가(#177)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/ilta/solepli/domain/place/controller/PlaceController.java
@@ -34,10 +34,13 @@ public class PlaceController {
   @GetMapping("/search")
   public ResponseEntity<SuccessResponse<List<PlaceSearchResponse>>> searchPlaces(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @RequestParam(required = true) String keyword) {
+      @RequestParam String keyword,
+      @RequestParam Double userLat,
+      @RequestParam Double userLng) {
 
     User user = SecurityUtil.getUser(customUserDetails);
-    List<PlaceSearchResponse> searchContents = placeService.getSearchPlaces(user, keyword);
+    List<PlaceSearchResponse> searchContents =
+        placeService.getSearchPlaces(user, keyword, userLat, userLng);
 
     return ResponseEntity.ok(SuccessResponse.successWithData(searchContents));
   }

--- a/src/main/java/com/ilta/solepli/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/ilta/solepli/domain/place/controller/PlaceController.java
@@ -35,8 +35,8 @@ public class PlaceController {
   public ResponseEntity<SuccessResponse<List<PlaceSearchResponse>>> searchPlaces(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @RequestParam String keyword,
-      @RequestParam Double userLat,
-      @RequestParam Double userLng) {
+      @RequestParam(required = false) Double userLat,
+      @RequestParam(required = false) Double userLng) {
 
     User user = SecurityUtil.getUser(customUserDetails);
     List<PlaceSearchResponse> searchContents =

--- a/src/main/java/com/ilta/solepli/domain/place/entity/SearchType.java
+++ b/src/main/java/com/ilta/solepli/domain/place/entity/SearchType.java
@@ -1,0 +1,6 @@
+package com.ilta.solepli.domain.place.entity;
+
+public enum SearchType {
+  PLACE_NAME,
+  ADDRESS
+}

--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryCustom.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryCustom.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import com.ilta.solepli.domain.place.dto.response.PlaceSearchResponseDTO;
+import com.ilta.solepli.domain.place.entity.SearchType;
 import com.ilta.solepli.domain.sollect.dto.response.SollectPlaceAddPreviewResponse;
 
 @Repository
@@ -16,7 +17,8 @@ public interface PlaceRepositoryCustom {
 
   Integer getRecommendationPercent(Long placeId);
 
-  List<PlaceSearchResponseDTO> getPlacesByKeyword(String keyword);
+  List<PlaceSearchResponseDTO> getPlacesByKeyword(
+      String keyword, Double userLat, Double userLng, SearchType searchType, Long limit);
 
   SollectPlaceAddPreviewResponse getSollectAddPreview(Long placeId);
 }

--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
@@ -212,34 +212,4 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
             })
         .toList();
   }
-
-  // 전체 Place 테이블의 id 범위를 저장할 자료형 정의
-  private static class IdRange {
-    long minId, maxId; // minId: 가장 작은 id, maxId: 가장 큰 id
-  }
-
-  // 스레드 간 가시성을 보장하면서 placeIdRangeCache 변수 캐싱 (lazy 초기화용)
-  private volatile IdRange placeIdRangeCache; // volatile: 값이 바뀌면 다른 스레드도 즉시 반영된 값을 볼 수 있음
-
-  // placeIdRangeCache가 없으면 min/max를 계산해서 채우고, 있으면 캐시된 값 반환
-  private IdRange getPlaceIdRange() {
-    // 1) 먼저 캐시된 값이 있는지 확인
-    IdRange cached = placeIdRangeCache;
-    if (cached != null) return cached; // 있으면 그대로 반환
-
-    // 2) 없으면 DB에서 직접 min/max id를 계산
-    Long minId = jpaQueryFactory.select(p.id.min()).from(p).fetchOne(); // 최솟값
-    Long maxId = jpaQueryFactory.select(p.id.max()).from(p).fetchOne(); // 최댓값
-
-    // 3) null 방지: 테이블이 비어 있을 경우 0으로 기본값 대체
-    cached = new IdRange();
-    cached.minId = minId == null ? 0L : minId;
-    cached.maxId = maxId == null ? 0L : maxId;
-
-    // 4) 계산된 범위를 캐시에 저장 (다음 호출 시 DB 쿼리 생략 가능)
-    placeIdRangeCache = cached;
-
-    // 5) 새로 계산한 범위 반환
-    return cached;
-  }
 }

--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.ilta.solepli.domain.place.repository;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,60 +100,41 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
   public List<PlaceSearchResponseDTO> getPlacesByKeyword(
       String keyword, Double userLat, Double userLng, SearchType searchType, Long limit) {
 
-    // 0) 조건
+    // 0) 검색 조건
     BooleanBuilder cond = new BooleanBuilder();
     if (searchType == SearchType.PLACE_NAME) cond.and(p.name.contains(keyword));
     else cond.and(p.address.contains(keyword));
 
-    NumberExpression<Double> dist = distance(userLat, userLng);
+    long k = (limit == null ? 10L : limit);
 
-    // 1) 루트(Place)만으로 거리 오름차순 + tie-breaker(p.id) + limit
-    //    - 컬렉션 fetch join 없음 → 인메모리 페이징 경고 제거
+    // 좌표가 있으면 거리순 정렬
+    if (userLat != null && userLng != null) {
+      NumberExpression<Double> dist = distance(userLat, userLng);
+      List<Tuple> rows =
+          jpaQueryFactory
+              .select(p.id, p.name, p.types, p.address, p.latitude, p.longitude)
+              .from(p)
+              .where(cond)
+              .orderBy(dist.asc(), p.id.asc())
+              .limit(k)
+              .fetch();
+
+      return assemblePlaceDTO(rows);
+    }
+
+    // 좌표가 없을 경우, 전부 가져온 다음, 섞고 자르기
     List<Tuple> rows =
         jpaQueryFactory
             .select(p.id, p.name, p.types, p.address, p.latitude, p.longitude)
             .from(p)
             .where(cond)
-            .orderBy(dist.asc(), p.id.asc())
-            .limit(limit == null ? 0 : limit) // null 방지 (필요시 기본값 사용)
+            .orderBy(p.id.asc())
             .fetch();
 
-    if (rows.isEmpty()) return List.of();
+    Collections.shuffle(rows);
+    if (rows.size() > k) rows = rows.subList(0, (int) k);
 
-    List<Long> placeIds = rows.stream().map(t -> t.get(p.id)).toList();
-
-    // 2) 메인 카테고리 맵 (각 place별 'PlaceCategory.id'가 가장 작은 카테고리의 이름 선택)
-    List<Tuple> cats =
-        jpaQueryFactory
-            .select(pc.place.id, pc.id, c.name)
-            .from(pc)
-            .join(pc.category, c)
-            .where(pc.place.id.in(placeIds))
-            .orderBy(pc.place.id.asc(), pc.id.asc())
-            .fetch();
-
-    Map<Long, String> mainCategoryMap = new LinkedHashMap<>();
-    for (Tuple t : cats) {
-      Long placeId = t.get(pc.place.id);
-      mainCategoryMap.putIfAbsent(placeId, t.get(c.name)); // 첫 행 = 최소 pc.id
-    }
-
-    // 3) DTO 조립 (rows 순서 == 거리순 유지)
-    return rows.stream()
-        .map(
-            t -> {
-              Long id = t.get(p.id);
-              return PlaceSearchResponseDTO.builder()
-                  .id(id)
-                  .name(t.get(p.name))
-                  .category(mainCategoryMap.get(id)) // 항상 존재 전제(없으면 null 가능)
-                  .detailedCategory(t.get(p.types))
-                  .address(t.get(p.address))
-                  .latitude(t.get(p.latitude))
-                  .longitude(t.get(p.longitude))
-                  .build();
-            })
-        .toList();
+    return assemblePlaceDTO(rows);
   }
 
   @Override
@@ -192,5 +174,72 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         p.longitude, // {2}
         userLng // {3}
         );
+  }
+
+  // 메인 카테고리 + DTO 조립
+  private List<PlaceSearchResponseDTO> assemblePlaceDTO(List<Tuple> rows) {
+    if (rows.isEmpty()) return List.of();
+    List<Long> placeIds = rows.stream().map(t -> t.get(p.id)).toList();
+
+    List<Tuple> cats =
+        jpaQueryFactory
+            .select(pc.place.id, pc.id, c.name)
+            .from(pc)
+            .join(pc.category, c)
+            .where(pc.place.id.in(placeIds))
+            .orderBy(pc.place.id.asc(), pc.id.asc())
+            .fetch();
+
+    Map<Long, String> mainCategoryMap = new LinkedHashMap<>();
+    for (Tuple t : cats) {
+      Long placeId = t.get(pc.place.id);
+      mainCategoryMap.putIfAbsent(placeId, t.get(c.name));
+    }
+
+    return rows.stream()
+        .map(
+            t -> {
+              Long id = t.get(p.id);
+              return PlaceSearchResponseDTO.builder()
+                  .id(id)
+                  .name(t.get(p.name))
+                  .category(mainCategoryMap.get(id))
+                  .detailedCategory(t.get(p.types))
+                  .address(t.get(p.address))
+                  .latitude(t.get(p.latitude))
+                  .longitude(t.get(p.longitude))
+                  .build();
+            })
+        .toList();
+  }
+
+  // 전체 Place 테이블의 id 범위를 저장할 자료형 정의
+  private static class IdRange {
+    long minId, maxId; // minId: 가장 작은 id, maxId: 가장 큰 id
+  }
+
+  // 스레드 간 가시성을 보장하면서 placeIdRangeCache 변수 캐싱 (lazy 초기화용)
+  private volatile IdRange placeIdRangeCache; // volatile: 값이 바뀌면 다른 스레드도 즉시 반영된 값을 볼 수 있음
+
+  // placeIdRangeCache가 없으면 min/max를 계산해서 채우고, 있으면 캐시된 값 반환
+  private IdRange getPlaceIdRange() {
+    // 1) 먼저 캐시된 값이 있는지 확인
+    IdRange cached = placeIdRangeCache;
+    if (cached != null) return cached; // 있으면 그대로 반환
+
+    // 2) 없으면 DB에서 직접 min/max id를 계산
+    Long minId = jpaQueryFactory.select(p.id.min()).from(p).fetchOne(); // 최솟값
+    Long maxId = jpaQueryFactory.select(p.id.max()).from(p).fetchOne(); // 최댓값
+
+    // 3) null 방지: 테이블이 비어 있을 경우 0으로 기본값 대체
+    cached = new IdRange();
+    cached.minId = minId == null ? 0L : minId;
+    cached.maxId = maxId == null ? 0L : maxId;
+
+    // 4) 계산된 범위를 캐시에 저장 (다음 호출 시 DB 쿼리 생략 가능)
+    placeIdRangeCache = cached;
+
+    // 5) 새로 계산한 범위 반환
+    return cached;
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/ilta/solepli/domain/place/repository/PlaceRepositoryImpl.java
@@ -1,8 +1,14 @@
 package com.ilta.solepli.domain.place.repository;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +17,7 @@ import com.ilta.solepli.domain.place.dto.response.PlaceSearchResponseDTO;
 import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.place.entity.QPlace;
 import com.ilta.solepli.domain.place.entity.QPlaceCategory;
+import com.ilta.solepli.domain.place.entity.SearchType;
 import com.ilta.solepli.domain.review.entity.QReview;
 import com.ilta.solepli.domain.review.entity.Review;
 import com.ilta.solepli.domain.review.entity.mapping.QReviewImage;
@@ -89,27 +96,62 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
   }
 
   @Override
-  public List<PlaceSearchResponseDTO> getPlacesByKeyword(String keyword) {
-    return jpaQueryFactory
-        .select(p)
-        .from(p)
-        .join(p.placeCategories, pc)
-        .join(pc.category, c)
-        .where(p.name.contains(keyword))
-        .limit(10)
-        .fetch()
-        .stream()
+  public List<PlaceSearchResponseDTO> getPlacesByKeyword(
+      String keyword, Double userLat, Double userLng, SearchType searchType, Long limit) {
+
+    // 0) 조건
+    BooleanBuilder cond = new BooleanBuilder();
+    if (searchType == SearchType.PLACE_NAME) cond.and(p.name.contains(keyword));
+    else cond.and(p.address.contains(keyword));
+
+    NumberExpression<Double> dist = distance(userLat, userLng);
+
+    // 1) 루트(Place)만으로 거리 오름차순 + tie-breaker(p.id) + limit
+    //    - 컬렉션 fetch join 없음 → 인메모리 페이징 경고 제거
+    List<Tuple> rows =
+        jpaQueryFactory
+            .select(p.id, p.name, p.types, p.address, p.latitude, p.longitude)
+            .from(p)
+            .where(cond)
+            .orderBy(dist.asc(), p.id.asc())
+            .limit(limit == null ? 0 : limit) // null 방지 (필요시 기본값 사용)
+            .fetch();
+
+    if (rows.isEmpty()) return List.of();
+
+    List<Long> placeIds = rows.stream().map(t -> t.get(p.id)).toList();
+
+    // 2) 메인 카테고리 맵 (각 place별 'PlaceCategory.id'가 가장 작은 카테고리의 이름 선택)
+    List<Tuple> cats =
+        jpaQueryFactory
+            .select(pc.place.id, pc.id, c.name)
+            .from(pc)
+            .join(pc.category, c)
+            .where(pc.place.id.in(placeIds))
+            .orderBy(pc.place.id.asc(), pc.id.asc())
+            .fetch();
+
+    Map<Long, String> mainCategoryMap = new LinkedHashMap<>();
+    for (Tuple t : cats) {
+      Long placeId = t.get(pc.place.id);
+      mainCategoryMap.putIfAbsent(placeId, t.get(c.name)); // 첫 행 = 최소 pc.id
+    }
+
+    // 3) DTO 조립 (rows 순서 == 거리순 유지)
+    return rows.stream()
         .map(
-            p ->
-                PlaceSearchResponseDTO.builder()
-                    .id(p.getId())
-                    .name(p.getName())
-                    .category(getMainCategory(p))
-                    .detailedCategory(p.getTypes())
-                    .address(p.getAddress())
-                    .latitude(p.getLatitude())
-                    .longitude(p.getLongitude())
-                    .build())
+            t -> {
+              Long id = t.get(p.id);
+              return PlaceSearchResponseDTO.builder()
+                  .id(id)
+                  .name(t.get(p.name))
+                  .category(mainCategoryMap.get(id)) // 항상 존재 전제(없으면 null 가능)
+                  .detailedCategory(t.get(p.types))
+                  .address(t.get(p.address))
+                  .latitude(t.get(p.latitude))
+                  .longitude(t.get(p.longitude))
+                  .build();
+            })
         .toList();
   }
 
@@ -135,5 +177,20 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
   /** 장소에 연결된 카테고리 중 첫 번째(대표) 카테고리명을 반환. */
   private String getMainCategory(Place place) {
     return place.getPlaceCategories().get(0).getCategory().getName();
+  }
+
+  // 장소 ~ 사용자 거리 계산(Haversine 공식, km단위)
+  private NumberExpression<Double> distance(double userLat, double userLng) {
+    return Expressions.numberTemplate(
+        Double.class,
+        "6371 * acos("
+            + " cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) +"
+            + " sin(radians({0})) * sin(radians({1}))"
+            + ")",
+        userLat, // {0}
+        p.latitude, // {1}
+        p.longitude, // {2}
+        userLng // {3}
+        );
   }
 }

--- a/src/main/java/com/ilta/solepli/domain/place/service/PlaceService.java
+++ b/src/main/java/com/ilta/solepli/domain/place/service/PlaceService.java
@@ -2,13 +2,13 @@ package com.ilta.solepli.domain.place.service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -30,6 +30,7 @@ import com.ilta.solepli.domain.place.dto.response.PlaceSearchResponseDTO;
 import com.ilta.solepli.domain.place.entity.Place;
 import com.ilta.solepli.domain.place.entity.PlaceCategory;
 import com.ilta.solepli.domain.place.entity.PlaceHour;
+import com.ilta.solepli.domain.place.entity.SearchType;
 import com.ilta.solepli.domain.place.repository.PlaceRepository;
 import com.ilta.solepli.domain.solmark.place.entity.SolmarkPlace;
 import com.ilta.solepli.domain.solmark.place.repository.SolmarkPlaceRepository;
@@ -55,19 +56,30 @@ public class PlaceService {
   private final SolmarkPlaceRepository solmarkPlaceRepository;
   private final CategoryRepository categoryRepository;
 
+  private static final Long MAX_SEARCH_COUNT = 10L;
+
   @Transactional(readOnly = true)
-  public List<PlaceSearchResponse> getSearchPlaces(User user, String keyword) {
-    List<PlaceSearchResponseDTO> responseDTOList = placeRepository.getPlacesByKeyword(keyword);
-    List<Long> placeIds = responseDTOList.stream().map(dto -> dto.id()).toList();
+  public List<PlaceSearchResponse> getSearchPlaces(
+      User user, String keyword, Double userLat, Double userLng) {
 
-    Set<Long> solmarkedPlaceIds = getSolmarkedPlaceIds(user, placeIds);
+    // 장소 이름에 keyword가 포함된 장소를 거리순으로 조회하여 반환
+    List<PlaceSearchResponse> placeNameResponse =
+        getSearchResponse(user, userLat, userLng, keyword, SearchType.PLACE_NAME, MAX_SEARCH_COUNT);
 
-    List<PlaceSearchResponse> response = new ArrayList<>();
-    for (PlaceSearchResponseDTO dto : responseDTOList) {
-      PlaceSearchResponse p = PlaceSearchResponse.from(dto, solmarkedPlaceIds.contains(dto.id()));
-      response.add(p);
-    }
-    return response;
+    // 주소로 검색해올 장소 갯수 계산
+    Long remainder = MAX_SEARCH_COUNT - placeNameResponse.stream().count();
+
+    // 주소에 keyword가 포함된 장소를 거리순으로 조회하여 반환
+    List<PlaceSearchResponse> addressResponse = null;
+
+    if (remainder > 0)
+      addressResponse =
+          getSearchResponse(user, userLat, userLng, keyword, SearchType.ADDRESS, remainder);
+
+    // 스트림을 합쳐서, 앞에서부터 MAX_SEARCH_COUNT개만 리스트로 수집
+    return Stream.concat(placeNameResponse.stream(), addressResponse.stream())
+        .limit(MAX_SEARCH_COUNT)
+        .toList();
   }
 
   public void requestAddPlace(CustomUserDetails customUserDetails, RequestAddPlaceRequest req) {
@@ -201,5 +213,27 @@ public class PlaceService {
             place.addPlaceHour(placeHour);
           });
     }
+  }
+
+  private List<PlaceSearchResponse> getSearchResponse(
+      User user,
+      Double userLat,
+      Double userLng,
+      String keyword,
+      SearchType searchType,
+      Long limit) {
+
+    List<PlaceSearchResponseDTO> responseDTOList =
+        placeRepository.getPlacesByKeyword(keyword, userLat, userLng, searchType, limit);
+    List<Long> placeIds = responseDTOList.stream().map(dto -> dto.id()).toList();
+    Set<Long> solmarkedPlaceIds = getSolmarkedPlaceIds(user, placeIds);
+
+    return responseDTOList.stream()
+        .map(
+            dto -> {
+              boolean isMarked = solmarkedPlaceIds.contains(dto.id());
+              return PlaceSearchResponse.from(dto, isMarked);
+            })
+        .toList();
   }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
#177
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
장소 검색시 검색어 조건에 장소의 주소도 추가완료했습니다.

그리고 장소 검색 쿼리를 3단계로 분리했습니다.

<details>
  <summary>기존 코드</summary>

 ```
@Override
  public List<PlaceSearchResponseDTO> getPlacesByKeyword(
      String keyword, Double userLat, Double userLng, SearchType searchType, Long limit) {

        BooleanBuilder cond = new BooleanBuilder();
        if (searchType == SearchType.PLACE_NAME) {
          cond.and(p.name.contains(keyword));
        } else {
          cond.and(p.address.contains(keyword));
        }

        return jpaQueryFactory
            .select(p)
            .distinct()
            .from(p)
            .join(p.placeCategories, pc)
            .fetchJoin()
            .join(pc.category, c)
            .fetchJoin()
            .where(cond)
            .orderBy(distance(userLat, userLng).asc())
            .limit(limit)
            .fetch()
            .stream()
            .map(
                p ->
                    PlaceSearchResponseDTO.builder()
                        .id(p.getId())
                        .name(p.getName())
                        .category(getMainCategory(p))
                        .detailedCategory(p.getTypes())
                        .address(p.getAddress())
                        .latitude(p.getLatitude())
                        .longitude(p.getLongitude())
                        .build())
            .toList();        
   }
```
</details>

### 문제점

1. **to-many `fetch join` + `limit` 조합으로 인한 인메모리 페이징**

```java
.join(p.placeCategories, pc).fetchJoin()
.join(pc.category, c).fetchJoin()
.orderBy(distance(...).asc())
.limit(limit
```

- **원인:** 컬렉션 `fetch join`(1:N)으로 결과 행이 **폭증(행 곱셈)** 하여 DB가 **행 기준 LIMIT**을 정확히 적용하기 어렵습니다.
    
    Hibernate는 이를 감지해 **DB에서 모두 읽은 뒤 애플리케이션 메모리에서 잘라내는 인메모리 페이징**으로 fallback(`HHH90003004`) 합니다.
    
- **영향:**
    - **네트워크/I/O 증가**: 불필요하게 많은 로우를 전송
    - **메모리/GC 부담**: 전부 적재 후 잘라냄
    - **정렬/페이징 왜곡 위험**: “Place 기준 상위 N개”가 아닌 “조인으로 불어난 행 중 상위 N행”이 먼저 잘려 의도와 불일치

2. **`distinct`로는 중복·비용 문제가 근본 해결되지 않음**

```java
select(p).distinct()
```

- **원인:** 조인으로 **먼저 중복 행을 생성**한 뒤, 그 다음 단계에서야 `distinct`(또는 세션 레벨 중복 제거)가 적용됩니다.
- **영향:** 이미 커진 결과를 가져온 뒤에 제거하므로 **I/O·메모리·중복 제거 연산 비용**이 그대로 발생합니다.
    
    → 결과적으로 **비용 증가** + 여전히 인메모리 페이징 이슈 잔존.
    
3. **대표 카테고리 선정의 불안정성 (`getMainCategory(p)`의 0번 인덱스 의존)**

```java
category(getMainCategory(p)) // 내부적으로 get(0)
```

- **원인:** JPA 컬렉션은 기본 **무정렬**입니다. `@OrderBy`가 없다면 `get(0)`이 **“최소 [PlaceCategory.id](http://placecategory.id/)”**를 보장하지 않습니다.
- **영향:** **잘못된 메인 카테고리 노출** 가능. 또한 특정 상황(지연 로딩/빈 컬렉션)에서 **예외 위험** 존재.

<details>
  <summary>바뀐 코드</summary>

 ```
@Override
  public List<PlaceSearchResponseDTO> getPlacesByKeyword(
      String keyword, Double userLat, Double userLng, SearchType searchType, Long limit) {

    // 0) 조건
    BooleanBuilder cond = new BooleanBuilder();
    if (searchType == SearchType.PLACE_NAME) cond.and(p.name.contains(keyword));
    else cond.and(p.address.contains(keyword));

    NumberExpression<Double> dist = distance(userLat, userLng);

    // 1) 루트(Place)만으로 거리 오름차순 + tie-breaker(p.id) + limit
    //    - 컬렉션 fetch join 없음 → 인메모리 페이징 경고 제거
    List<Tuple> rows =
        jpaQueryFactory
            .select(p.id, p.name, p.types, p.address, p.latitude, p.longitude, dist)
            .from(p)
            .where(cond)
            .orderBy(dist.asc(), p.id.asc())
            .limit(limit == null ? 0 : limit) // null 방지 (필요시 기본값 사용)
            .fetch();

    if (rows.isEmpty()) return List.of();

    List<Long> placeIds = rows.stream().map(t -> t.get(p.id)).toList();

    // 2) 메인 카테고리 맵 (각 place별 'PlaceCategory.id'가 가장 작은 카테고리의 이름 선택)
    List<Tuple> cats =
        jpaQueryFactory
            .select(pc.place.id, pc.id, c.name)
            .from(pc)
            .join(pc.category, c)
            .where(pc.place.id.in(placeIds))
            .orderBy(pc.place.id.asc(), pc.id.asc())
            .fetch();

    Map<Long, String> mainCategoryMap = new LinkedHashMap<>();
    for (Tuple t : cats) {
      Long placeId = t.get(pc.place.id);
      mainCategoryMap.putIfAbsent(placeId, t.get(c.name)); // 첫 행 = 최소 pc.id
    }

    // 3) DTO 조립 (rows 순서 == 거리순 유지)
    return rows.stream()
        .map(
            t -> {
              Long id = t.get(p.id);
              return PlaceSearchResponseDTO.builder()
                  .id(id)
                  .name(t.get(p.name))
                  .category(mainCategoryMap.get(id)) // 항상 존재 전제(없으면 null 가능)
                  .detailedCategory(t.get(p.types))
                  .address(t.get(p.address))
                  .latitude(t.get(p.latitude))
                  .longitude(t.get(p.longitude))
                  // .distance((Double) t.get("dist")) // DTO에 거리 필드가 있으면 추가
                  .build();
            })
        .toList();
  }
```
</details>

### 변경 목적

- **인메모리 페이징 제거:** 기존 구현은 to-many `fetch join` + `limit`로 인해 `HHH90003004` 경고가 발생하고, DB가 아닌 **애플리케이션 메모리에서 페이징**되어 성능/메모리 비용이 컸습니다.
- **정확한 정렬/페이징 보장:** **루트 엔티티만**으로 거리 정렬 + `limit`을 적용해 **DB 차원의 정확한 페이징**을 보장합니다.
- **메인 카테고리 규칙 준수:** 비즈 규칙인 “**PlaceCategory.id가 가장 작은 항목이 메인**”을 확실히 반영합니다(이전엔 순서 보장이 불명확).
- **과도한 엔티티 로딩/중복 감소:** 불필요한 컬렉션 `fetch join`을 페이징 쿼리에서 제거해 **행 폭발(row explosion)**과 `distinct` 의존을 줄였습니다.

### 구현 요약 (3단계)

1. **1단계 – 루트만 거리 정렬 + limit**
    - 쿼리: `Place`에서 **거리 오름차순 + tie-breaker(`p.id`) + limit**로 조회.
    - 산출: 거리순 `rows`와 `placeIds`.
    - 효과: 페이징을 **DB에서 정확히** 수행 → `HHH90003004` 제거, 성능 안정.
2. **2단계 – 메인 카테고리 맵 생성**
    - 쿼리: `placeIds` 대상 `PlaceCategory` ↔ `Category` 조인, **`pc.place.id ASC, pc.id ASC`** 정렬.
    - 처리: 정렬된 결과를 순회하며 `putIfAbsent`로 첫 행(= 최소 `pc.id`)의 `Category.name`만 채택.
    - 산출: `Map<Long /*placeId*/, String /*mainCategoryName*/>`.
3. **3단계 – DTO 조립(거리순 유지)**
    - 1단계의 `rows` 순서를 **그대로 보존**하여 DTO를 생성하고, 2단계 맵에서 메인 카테고리명을 주입.
    - 필요 시 `dist`를 DTO에 포함해 디버깅/검증 용도로 출력 가능.


### 사용자의 좌표가 null일 경우
 ```
List<Tuple> rows =
        jpaQueryFactory
            .select(p.id, p.name, p.types, p.address, p.latitude, p.longitude)
            .from(p)
            .where(cond)
            .orderBy(p.id.asc())
            .fetch();

    Collections.shuffle(rows);
    if (rows.size() > k) rows = rows.subList(0, (int) k);

    return assemblePlaceDTO(rows);
```
사용자의 좌표가 없는 경우에는 조건에 맞는 모든 데이터를 조회한 뒤 `Collections.shuffle()`을 적용하여 무작위로 응답하도록 처리했습니다.
현재는 전체 데이터를 메모리에 로드하는 방식이지만, 조건에 맞는 데이터이 많아질 경우 성능 이슈가 발생할 수 있으므로, 나중에 데이터가 많아져 성능 이슈가 발생한다면 그때 리팩토링해보면 좋을거 같습니다!
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링

