### PR TITLE
Refactor: 동일 제목 쏠루트 저장 시 번호 자동 부여 (#187)

### DIFF
--- a/src/main/java/com/ilta/solepli/domain/solroute/repository/SolrouteRepository.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/repository/SolrouteRepository.java
@@ -22,4 +22,6 @@ public interface SolrouteRepository extends JpaRepository<Solroute, Long> {
   @Query(
       "SELECT s FROM Solroute s WHERE s.user = :user AND s.deletedAt IS NULL ORDER BY s.createdAt DESC")
   List<Solroute> findAllByUserId(User user);
+
+  Optional<Solroute> findTop1ByUserAndNameStartingWithOrderByIdDesc(User user, String name);
 }

--- a/src/main/java/com/ilta/solepli/domain/solroute/service/SolrouteService.java
+++ b/src/main/java/com/ilta/solepli/domain/solroute/service/SolrouteService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -42,11 +43,16 @@ public class SolrouteService {
   private final PlaceRepository placeRepository;
   private final SolmarkPlaceRepository solmarkPlaceRepository;
 
+  private static final int INITIAL_SUFFIX = 1;
+  private static final String SUFFIX_SEPARATOR = " "; // 접미사 구분자
+
   @Transactional
   public void createSolroute(User user, SolrouteCreateRequest request) {
 
+    String uniqueName = generateUniqueName(user, request.name());
+
     Solroute solroute =
-        Solroute.builder().iconId(request.iconId()).name(request.name()).user(user).build();
+        Solroute.builder().iconId(request.iconId()).name(uniqueName).user(user).build();
 
     List<PlaceInfo> placeInfos = request.placeInfos();
     for (PlaceInfo placeInfo : placeInfos) {
@@ -244,5 +250,29 @@ public class SolrouteService {
     return solrouteRepository
         .findByIdAndUserWithPlaces(solrouteId, user)
         .orElseThrow(() -> new CustomException(ErrorCode.SOLROUTE_ACCESS_DENIED));
+  }
+
+  private String generateUniqueName(User user, String baseName) {
+    Optional<Solroute> latest =
+        solrouteRepository.findTop1ByUserAndNameStartingWithOrderByIdDesc(user, baseName);
+
+    if (latest.isEmpty()) return baseName;
+
+    String latestName = latest.get().getName();
+
+    // baseName 자체만 있는 경우 (e.g. "여행") → "여행1"부터 시작
+    if (latestName.equals(baseName)) {
+      return baseName + SUFFIX_SEPARATOR + INITIAL_SUFFIX;
+    }
+
+    // baseName 뒤에 숫자가 붙어 있다면 파싱
+    String suffixStr = latestName.substring(baseName.length()).trim();
+    try {
+      int suffix = Integer.parseInt(suffixStr);
+      return baseName + SUFFIX_SEPARATOR + (suffix + 1);
+    } catch (NumberFormatException e) {
+      // 잘못된 숫자 형식인 경우 fallback
+      return baseName + SUFFIX_SEPARATOR + INITIAL_SUFFIX;
+    }
   }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
#187
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
동일한 제목의 쏠루트를 저장할 경우, 중복을 방지하기 위해 제목 끝에 숫자를 자동으로 붙이도록 로직을 수정했습니다.
ex) `여행`, `여행 1`, `여행 2` …

`Optional<Solroute> findTop1ByUserAndNameStartingWithOrderByIdDesc(User user, String name);`
위와 같은 JPA 메소드를 이용하여 유저의 쏠렉트 중 특정 문자열로 시작하는 제목을 가진 가장 최신 쏠루트(가장 최신 쏠루트 -> 접미 숫자가 가장 큰 쏠루트)를 가져온 후에 접미 숫자를 계산해 새로운 제목을 생성합니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링
